### PR TITLE
Feat: deleted records are immutable

### DIFF
--- a/schema/deploy/trigger_functions/deleted_records_are_immutable.sql
+++ b/schema/deploy/trigger_functions/deleted_records_are_immutable.sql
@@ -5,10 +5,8 @@ begin;
 create or replace function cif_private.deleted_records_are_immutable()
 returns trigger as $$
 begin
-  if to_jsonb(old) ? 'deleted_at' then
-    if old.deleted_at is not null then
-      raise exception 'Deleted records cannot be modified';
-    end if;
+  if old.deleted_at is not null then
+    raise exception 'Deleted records cannot be modified';
   end if;
   return new;
 end;

--- a/schema/deploy/trigger_functions/deleted_records_are_immutable.sql
+++ b/schema/deploy/trigger_functions/deleted_records_are_immutable.sql
@@ -1,0 +1,25 @@
+-- Deploy cif:trigger_functions/deleted_records_are_immutable to pg
+
+begin;
+
+create or replace function cif_private.deleted_records_are_immutable()
+returns trigger as $$
+begin
+  if to_jsonb(old) ? 'deleted_at' then
+    if old.deleted_at is not null then
+      raise exception 'Deleted records cannot be modified';
+    end if;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+grant execute on function cif_private.deleted_records_are_immutable to cif_internal, cif_external, cif_admin;
+
+comment on function cif_private.deleted_records_are_immutable()
+  is $$
+  A trigger that raises an exception if changes happen on a record where ''deleted_at'' is set.
+  $$;
+
+
+commit;

--- a/schema/deploy/util_functions/upsert_timestamp_columns.sql
+++ b/schema/deploy/util_functions/upsert_timestamp_columns.sql
@@ -84,6 +84,7 @@ begin
   if not exists (select *
     from information_schema.triggers
     where event_object_table = table_name
+    and event_object_schema = table_schema_name
     and trigger_name = '_100_timestamps'
   ) then
     trigger_string := concat(
@@ -93,12 +94,28 @@ begin
     execute(trigger_string);
   end if;
 
+  if not exists (select *
+    from information_schema.triggers
+    where event_object_table = table_name
+    and event_object_schema = table_schema_name
+    and trigger_name = '_050_immutable_deleted_records'
+  ) then
+    trigger_string := concat(
+      'create trigger _050_immutable_deleted_records before update on ', table_schema_name, '.', table_name,
+      ' for each row execute procedure cif_private.deleted_records_are_immutable()'
+    );
+    execute(trigger_string);
+  end if;
+
 end;
 $$ language plpgsql;
 
 comment on function cif_private.upsert_timestamp_columns(text, text, boolean, boolean, boolean, text, text)
   is $$
-  an internal function that adds the created/updated/deleted at/by columns, indices on fkeys and applies the _100_timestamps trigger
+  an internal function that adds the created/updated/deleted at/by columns, indices on fkeys,
+  applies the _100_timestamps trigger,
+  applies the _050_immutable_deleted_records trigger
+
   example usage:
 
   create table some_schema.some_table (

--- a/schema/revert/trigger_functions/deleted_records_are_immutable.sql
+++ b/schema/revert/trigger_functions/deleted_records_are_immutable.sql
@@ -1,0 +1,7 @@
+-- Revert cif:trigger_functions/deleted_records_are_immutable from pg
+
+begin;
+
+drop function cif_private.deleted_records_are_immutable;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -18,6 +18,7 @@ tables/connect_session 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.i
 types/keycloak_jwt 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.is> # Create the cif.keycloak_jwt type
 functions/session 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.is> # Create the cif.session function
 trigger_functions/update_timestamps 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.is> # Create the cif_private.update_timestamps trigger function
+trigger_functions/deleted_records_are_immutable 2022-01-06T18:37:08Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A trigger to ensure that no changes to a deleted record can be saved
 util_functions/upsert_timestamp_columns [schemas/private trigger_functions/update_timestamps] 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.is> # Create the upsert_timestamp_columns function
 tables/cif_user 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.is> # Create the cif.cif_user table
 trigger_functions/set_user_id 2021-10-21T16:10:32Z Matthieu Foucault <matthieu@button.is> # Create the cif_private.set_user_id trigger function

--- a/schema/test/unit/trigger_functions/deleted_records_are_immutable_test.sql
+++ b/schema/test/unit/trigger_functions/deleted_records_are_immutable_test.sql
@@ -2,7 +2,7 @@
 
 begin;
 
-select plan(4);
+select plan(3);
 
 -- Testing table with a deleted_at column
 
@@ -37,22 +37,5 @@ select throws_ok(
   'throws if deleted_at is set'
 );
 
--- Testing table without deleted_at column
-
-create table test_table_without_column(
-  test_col text
-);
-
-create trigger _1_trigger_under_test before update on test_table_without_column for each row
-execute procedure cif_private.deleted_records_are_immutable();
-
-insert into test_table_without_column(test_col) values ('test_value');
-
-select lives_ok(
-  $$
-    update test_table_without_column set test_col = 'updated!' where test_col = 'test_value'
-  $$,
-  'doesnt throw if there is no deleted_at column'
-);
 
 rollback;

--- a/schema/test/unit/trigger_functions/deleted_records_are_immutable_test.sql
+++ b/schema/test/unit/trigger_functions/deleted_records_are_immutable_test.sql
@@ -1,0 +1,58 @@
+
+
+begin;
+
+select plan(4);
+
+-- Testing table with a deleted_at column
+
+create table test_table_with_column(
+  test_col text,
+  deleted_at timestamptz default null
+);
+
+create trigger _1_trigger_under_test before update on test_table_with_column for each row
+execute procedure cif_private.deleted_records_are_immutable();
+
+insert into test_table_with_column(test_col, deleted_at) values ('test_active', null), ('test_deleted', '2022-01-01 11:00:00.0-08');
+
+select lives_ok(
+  $$
+    update test_table_with_column set test_col = 'test_changed_active' where test_col = 'test_active'
+  $$,
+  'doesnt throw if deleted_at is not set'
+);
+
+select is(
+  (select count(*) from test_table_with_column where test_col = 'test_changed_active'),
+  1::bigint,
+  'allows the record to be updated if deleted_at is not set'
+);
+
+select throws_ok(
+  $$
+    update test_table_with_column set test_col = 'test_changed_deleted' where test_col = 'test_deleted'
+  $$,
+  'Deleted records cannot be modified',
+  'throws if deleted_at is set'
+);
+
+-- Testing table without deleted_at column
+
+create table test_table_without_column(
+  test_col text
+);
+
+create trigger _1_trigger_under_test before update on test_table_without_column for each row
+execute procedure cif_private.deleted_records_are_immutable();
+
+insert into test_table_without_column(test_col) values ('test_value');
+
+select lives_ok(
+  $$
+    update test_table_without_column set test_col = 'updated!' where test_col = 'test_value'
+  $$,
+  'doesnt throw if there is no deleted_at column'
+);
+
+rollback;

--- a/schema/test/unit/util_functions/upsert_timestamp_columns_test.sql
+++ b/schema/test/unit/util_functions/upsert_timestamp_columns_test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(22);
+select plan(23);
 
 create table cif.test_table_all_columns
 (
@@ -123,7 +123,18 @@ select isnt_empty(
       and event_object_schema = 'cif'
       and trigger_name = '_050_immutable_deleted_records'
   $$,
-  'the immutable deleted records trigger is added'
+  'the immutable deleted records trigger is added when deleted_at is added'
+);
+
+select is_empty(
+  $$
+    select trigger_name
+      from information_schema.triggers
+      where event_object_table = 'test_table_false_columns'
+      and event_object_schema = 'cif'
+      and trigger_name = '_050_immutable_deleted_records'
+  $$,
+  'the immutable deleted records trigger is not added when deleted_at is not added'
 );
 
 select finish();

--- a/schema/test/unit/util_functions/upsert_timestamp_columns_test.sql
+++ b/schema/test/unit/util_functions/upsert_timestamp_columns_test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(20);
+select plan(22);
 
 create table cif.test_table_all_columns
 (
@@ -100,6 +100,30 @@ select hasnt_index(
 select hasnt_index(
   'cif', 'test_table_false_columns', 'cif_test_table_false_columns_deleted_by_foreign_key',
   'test_table_false_columns does not create an index when deleted_by parameter is false'
+);
+
+-- triggers are added
+
+select isnt_empty(
+  $$
+    select trigger_name
+      from information_schema.triggers
+      where event_object_table = 'test_table_all_columns'
+      and event_object_schema = 'cif'
+      and trigger_name = '_100_timestamps'
+  $$,
+  'the timestamps trigger is added'
+);
+
+select isnt_empty(
+  $$
+    select trigger_name
+      from information_schema.triggers
+      where event_object_table = 'test_table_all_columns'
+      and event_object_schema = 'cif'
+      and trigger_name = '_050_immutable_deleted_records'
+  $$,
+  'the immutable deleted records trigger is added'
 );
 
 select finish();

--- a/schema/verify/trigger_functions/deleted_records_are_immutable.sql
+++ b/schema/verify/trigger_functions/deleted_records_are_immutable.sql
@@ -1,0 +1,7 @@
+-- Verify cif:trigger_functions/deleted_records_are_immutable on pg
+
+begin;
+
+select pg_get_functiondef('cif_private.deleted_records_are_immutable()'::regprocedure);
+
+rollback;


### PR DESCRIPTION
A trigger making sure that deleted records can't be updated.
It gets automatically added with the `deleted_at` column