### PR TITLE
Feat: committed changes are immutable

### DIFF
--- a/schema/deploy/tables/form_change.sql
+++ b/schema/deploy/tables/form_change.sql
@@ -22,6 +22,11 @@ create trigger commit_form_change
     when (new.change_status = 'committed')
     execute procedure cif_private.commit_form_change();
 
+create trigger committed_changes_are_immutable
+    before update on cif.form_change
+    for each row
+    execute procedure cif_private.committed_changes_are_immutable();
+
 do
 $grant$
 begin

--- a/schema/deploy/tables/form_change.sql
+++ b/schema/deploy/tables/form_change.sql
@@ -16,16 +16,18 @@ create table cif.form_change (
 
 select cif_private.upsert_timestamp_columns('cif', 'form_change');
 
+-- We want the immutable trigger to run first to avoid doing unnecessary work
+create trigger _100_committed_changes_are_immutable
+    before update on cif.form_change
+    for each row
+    execute procedure cif_private.committed_changes_are_immutable();
+
 create trigger commit_form_change
-    after insert or update of change_status on cif.form_change
+    before insert or update of change_status on cif.form_change
     for each row
     when (new.change_status = 'committed')
     execute procedure cif_private.commit_form_change();
 
-create trigger committed_changes_are_immutable
-    before update on cif.form_change
-    for each row
-    execute procedure cif_private.committed_changes_are_immutable();
 
 do
 $grant$

--- a/schema/deploy/tables/project_revision.sql
+++ b/schema/deploy/tables/project_revision.sql
@@ -10,15 +10,16 @@ create table cif.project_revision (
 
 select cif_private.upsert_timestamp_columns('cif', 'project_revision');
 
-create trigger commit_project_revision
-    after insert or update of change_status on cif.project_revision
-    for each row
-    execute procedure cif_private.commit_project_revision();
-
-create trigger committed_changes_are_immutable
+-- We want the immutable trigger to run first to avoid doing unnecessary work
+create trigger _100_committed_changes_are_immutable
     before update on cif.project_revision
     for each row
     execute procedure cif_private.committed_changes_are_immutable();
+
+create trigger commit_project_revision
+    before insert or update of change_status on cif.project_revision
+    for each row
+    execute procedure cif_private.commit_project_revision();
 
 do
 $grant$

--- a/schema/deploy/tables/project_revision.sql
+++ b/schema/deploy/tables/project_revision.sql
@@ -15,6 +15,11 @@ create trigger commit_project_revision
     for each row
     execute procedure cif_private.commit_project_revision();
 
+create trigger committed_changes_are_immutable
+    before update on cif.project_revision
+    for each row
+    execute procedure cif_private.committed_changes_are_immutable();
+
 do
 $grant$
 begin

--- a/schema/deploy/trigger_functions/commit_project_revision.sql
+++ b/schema/deploy/trigger_functions/commit_project_revision.sql
@@ -21,18 +21,16 @@ begin
 
   -- If a project_id wasn't created, save it after the form_change row was committed
   if (select triggers_commit from cif.change_status where status=new.change_status) and (new.project_id is null) then
-      update cif.project_revision set project_id=(
-          select form_data_record_id
-            from cif.form_change
-            where project_revision_id=new.id
-              and form_data_table_name='project'
-              and form_data_schema_name='cif'
-          )
-        where id=new.id;
+    new.project_id = (
+      select form_data_record_id
+        from cif.form_change
+        where project_revision_id=new.id
+          and form_data_table_name='project'
+          and form_data_schema_name='cif'
+      );
   end if;
 
   return new;
-
 end;
 $$ language plpgsql;
 

--- a/schema/deploy/trigger_functions/committed_changes_are_immutable.sql
+++ b/schema/deploy/trigger_functions/committed_changes_are_immutable.sql
@@ -8,7 +8,6 @@ begin
   if (select triggers_commit from cif.change_status where status=old.change_status) then
     raise exception 'Committed records cannot be modified';
   end if;
-
   return new;
 end;
 $$ language plpgsql;

--- a/schema/deploy/trigger_functions/committed_changes_are_immutable.sql
+++ b/schema/deploy/trigger_functions/committed_changes_are_immutable.sql
@@ -1,0 +1,24 @@
+-- Deploy cif:trigger_functions/committed_changes_are_immutable to pg
+
+begin;
+
+create or replace function cif_private.committed_changes_are_immutable()
+returns trigger as $$
+begin
+  if (select triggers_commit from cif.change_status where status=old.change_status) then
+    raise exception 'Committed records cannot be modified';
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+grant execute on function cif_private.committed_changes_are_immutable to cif_internal, cif_external, cif_admin;
+
+comment on function cif_private.committed_changes_are_immutable()
+  is $$
+  A trigger that raises an exception if changes happen on a record where the change_status triggers a commit.
+  $$;
+
+
+commit;

--- a/schema/revert/trigger_functions/committed_changes_are_immutable.sql
+++ b/schema/revert/trigger_functions/committed_changes_are_immutable.sql
@@ -1,0 +1,7 @@
+-- Revert cif:trigger_functions/committed_changes_are_immutable from pg
+
+begin;
+
+drop function cif_private.committed_changes_are_immutable;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -29,6 +29,7 @@ tables/project [tables/operator] 2021-11-04T20:34:23Z Pierre Bastianelli <pierre
 util_functions/camel_to_snake_case 2021-12-11T00:37:54Z Matthieu Foucault <matthieu@button.is> # Add cif_private.camel_to_snake_case
 trigger_functions/commit_form_change [schemas/private util_functions/camel_to_snake_case] 2021-11-08T22:54:27Z Dylan Leard <dylan@button.is> # Trigger function to apply changes to a table once the change has been committed
 tables/change_status [schemas/main] 2021-11-08T22:46:03Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Table to constrain the status of a form_change row
+trigger_functions/committed_changes_are_immutable 2022-01-06T23:40:27Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Trigger to prevent committed changes from being altered
 trigger_functions/commit_project_revision 2021-12-07T00:37:33Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A trigger function executed when a whole project revision is committed, triggering commit on the individual form_change records
 tables/project_revision 2021-12-07T00:39:51Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track global project revisions - containing multiple changes
 tables/form_change [tables/change_status] 2021-11-04T20:58:49Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Form history table to track changes to records

--- a/schema/test/unit/tables/project_revision_test.sql
+++ b/schema/test/unit/tables/project_revision_test.sql
@@ -1,0 +1,42 @@
+
+
+begin;
+
+select plan(2);
+
+-- Test setup --
+insert into cif.operator(legal_name) values ('test operator');
+insert into cif.funding_stream(name, description) values ('test funding stream', 'desc');
+insert into cif.project(project_name, operator_id, funding_stream_id, rfp_number, summary)
+  values (
+    'test-project',
+    (select id from cif.operator limit 1),
+    (select id from cif.funding_stream limit 1),
+    'rfp',
+    'summary'
+  );
+
+
+-- Trigger tests --
+
+insert into cif.change_status(status, triggers_commit) values ('testcommitted', true), ('testpending', false), ('testpending_2', false);
+insert into cif.project_revision(project_id, change_status) values ((select id from cif.project limit 1), 'testpending'), ((select id from cif.project limit 1), 'testcommitted');
+
+select lives_ok(
+  $$
+    update cif.project_revision set change_status = 'testpending_2' where change_status='testpending'
+  $$,
+  'allows update if the change status is pending'
+);
+
+select throws_ok(
+  $$
+    update cif.project_revision set change_status = 'testpending_2' where change_status='testcommitted'
+  $$,
+  'Committed records cannot be modified',
+  'prevents update if the change status is committed'
+);
+
+select finish();
+
+rollback;

--- a/schema/test/unit/trigger_functions/committed_changes_are_immutable_test.sql
+++ b/schema/test/unit/trigger_functions/committed_changes_are_immutable_test.sql
@@ -1,0 +1,41 @@
+begin;
+
+select plan(3);
+
+-- Testing table with a deleted_at column
+
+insert into cif.change_status (status, triggers_commit, active) values ('testcommitted', true, true), ('testpending', false, true);
+
+create table test_table_with_status(
+  test_col text,
+  change_status varchar(1000) references cif.change_status
+);
+
+create trigger trigger_under_test before update on test_table_with_status for each row
+execute procedure cif_private.committed_changes_are_immutable();
+
+insert into test_table_with_status(test_col, change_status) values ('test_active', 'testpending'), ('test_committed', 'testcommitted');
+
+select lives_ok(
+  $$
+    update test_table_with_status set test_col = 'test_changed_active' where test_col = 'test_active'
+  $$,
+  'doesnt throw if the change status isn''t committed'
+);
+
+select is(
+  (select count(*) from test_table_with_status where test_col = 'test_changed_active'),
+  1::bigint,
+  'allows the record to be updated if the change status isn''t committed'
+);
+
+select throws_ok(
+  $$
+    update test_table_with_status set test_col = 'test_changed_committed' where test_col = 'test_committed'
+  $$,
+  'Committed records cannot be modified',
+  'throws if the change_status is committed'
+);
+
+
+rollback;

--- a/schema/test/unit/trigger_functions/committed_changes_are_immutable_test.sql
+++ b/schema/test/unit/trigger_functions/committed_changes_are_immutable_test.sql
@@ -2,8 +2,6 @@ begin;
 
 select plan(3);
 
--- Testing table with a deleted_at column
-
 insert into cif.change_status (status, triggers_commit, active) values ('testcommitted', true, true), ('testpending', false, true);
 
 create table test_table_with_status(
@@ -37,5 +35,6 @@ select throws_ok(
   'throws if the change_status is committed'
 );
 
+select finish();
 
 rollback;

--- a/schema/verify/trigger_functions/committed_changes_are_immutable.sql
+++ b/schema/verify/trigger_functions/committed_changes_are_immutable.sql
@@ -1,0 +1,7 @@
+-- Verify cif:trigger_functions/committed_changes_are_immutable on pg
+
+begin;
+
+select pg_get_functiondef('cif_private.committed_changes_are_immutable()'::regprocedure);
+
+rollback;


### PR DESCRIPTION
Making sure that committed `project_revision` and `form_change` records can't be altered