### PR TITLE
chore: only format and lint committed files

### DIFF
--- a/.bin/pre-commit-format.sh
+++ b/.bin/pre-commit-format.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+pushd app || exit 1
+files=("$@")
+files=("${files[@]/#/../}") # add ../ to each element
+
+# --ignore-unknown prevents prettier from complaining about file types it doesn't know about
+yarn run prettier --ignore-unknown --write "${files[@]}"

--- a/.bin/pre-commit-lint.sh
+++ b/.bin/pre-commit-lint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+pushd app || exit 1
+files=("$@")
+files=("${files[@]/#/../}") # add ../ to each element
+
+yarn run eslint "${files[@]}"

--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -3,8 +3,7 @@ name: Bug template
 about: For documenting bugs as per our bug process
 title: "[bug title]"
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 Describe the Bug:

--- a/.github/ISSUE_TEMPLATE/task-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/task-issue-template.md
@@ -1,11 +1,11 @@
 ---
 name: Task issue template
-about: For cards that are not user stories, but may be technical, UX-related, or other
+about:
+  For cards that are not user stories, but may be technical, UX-related, or other
   tasks.
 title: "[title of task]"
 labels: Task
-assignees: ''
-
+assignees: ""
 ---
 
 #### Describe the task

--- a/.github/ISSUE_TEMPLATE/user-story-template.md
+++ b/.github/ISSUE_TEMPLATE/user-story-template.md
@@ -1,26 +1,30 @@
 ---
 name: User Story Template
-about: User stories are broken down product backlog items that are user-focused and
+about:
+  User stories are broken down product backlog items that are user-focused and
   vertically-sliced.
 title: As a [user], I want to [what], so that [why]
 labels: User Story
-assignees: ''
-
+assignees: ""
 ---
 
 #### Description:
+
 Brief description of the work involved, including any user research context or key decisions.
 
 #### Acceptance Criteria:
+
 Given
 When
 Then
 
 #### Development Checklist:
+
 - [ ] Checklist item
 - [ ] Checklist item
 - [ ] Checklist item
 - [ ] Meets the DOD
 
 #### Notes:
+
 -

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,17 @@ exclude: >
 repos:
   - repo: local
     hooks:
-      - id: eslint-prettier
-        name: Lint and Style
+      - id: prettier
+        name: Prettier
+        language: script
+        entry: ./.bin/pre-commit-format.sh
+  - repo: local
+    hooks:
+      - id: eslint
+        name: ESLint
         language: system
-        entry: bash -c 'pushd app; yarn format && yarn lint'
-        pass_filenames: false
+        files: \.(j|t)sx?$
+        entry: ./.bin/pre-commit-lint.sh
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "eslint.workingDirectories": [
-    "app"
-  ],
+  "eslint.workingDirectories": ["app"],
   "sqltools.connections": [
     {
       "previewLimit": 50,

--- a/COMPLIANCE.yaml
+++ b/COMPLIANCE.yaml
@@ -5,7 +5,7 @@ description: |
 spec:
   - name: PIA
     status: in-progress
-    last-updated: '2021-09-03T18:25:25.166Z'
+    last-updated: "2021-09-03T18:25:25.166Z"
   - name: STRA
     status: in-progress
-    last-updated: '2021-09-03T18:25:25.166Z'
+    last-updated: "2021-09-03T18:25:25.166Z"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # cas-cif
+
 CleanBC Industry Fund project
 
 ![Lifecycle:Maturing](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)

--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -5,3 +5,4 @@ dist/
 server/schema.json
 server/schema.graphql
 coverage
+../chart/**/templates/**/*.yaml

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,16 +1,20 @@
 # Storage Micro-Service Application for CIF
 
 ## Description
+
 The storage directory contains the FastAPI S3 api wrapper that is used to
 upload and download attachment documents related to CIF Projects.
 
 ## Notes
+
 The api allows upload, download, delete, and download files as a zip
 
 ## Test curl examples
 
 ### upload
+
 curl -H "api-key: <api-key>" --form "files=@cif-test-document.docx" http://localhost:8000/api/v1/attachments/upload
 
 ### download
+
 curl -X POST http://localhost:8000/api/v1/attachments/download -H "api-key: <api-key>" -H 'Content-Type: application/json' -d '{"attachment":{"uuid":"f16b738c-3afb-4c24-a64a-88d0d98dca1a"}}'

--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 services:
   api:
     build:
@@ -18,7 +18,7 @@ services:
       MINIO_HOST_URL: "${MINIO_HOST_URL}"
       STORAGE_API_KEY: "${STORAGE_API_KEY}"
     ports:
-      - '8000:8000'
+      - "8000:8000"
   minio:
     image: minio/minio:RELEASE.2021-04-22T15-44-28Z
     volumes:


### PR DESCRIPTION
- only runs prettier and eslint on committed files (much faster pre-commit hook)
- all files are formatted by prettier (not only the ones in the `app` folder)
- only passes js/ts files to eslint, in a separate pre-commit hook as it will complain if given any other file format