### PR TITLE
Fix: SessionTimeoutHandler doesn't render after the session expires

### DIFF
--- a/app/components/Session/SessionExpiryHandler.tsx
+++ b/app/components/Session/SessionExpiryHandler.tsx
@@ -33,6 +33,7 @@ const SessionExpiryHandler: React.FC = () => {
   }, []);
 
   const handleSessionExpired = () => {
+    setHasSession(false);
     router.push({
       pathname: "/login-redirect",
       query: {

--- a/app/tests/unit/components/Session/SessionExpiryHandler.test.tsx
+++ b/app/tests/unit/components/Session/SessionExpiryHandler.test.tsx
@@ -1,0 +1,41 @@
+import { act, render } from "@testing-library/react";
+import SessionExpiryHandler from "components/Session/SessionExpiryHandler";
+
+describe("The SessionExpiryHandler component", () => {
+  it("renders the SessionTimeoutHandler component when a session is present", () => {
+    const mockSessionTimeoutHandler = jest
+      .fn()
+      .mockImplementation(() => <div>aaa</div>);
+
+    jest
+      .spyOn(require("@bcgov-cas/sso-react"), "SessionTimeoutHandler")
+      .mockImplementation(() => mockSessionTimeoutHandler);
+
+    jest
+      .spyOn(require("next/router"), "useRouter")
+      .mockImplementation(() => jest.fn());
+
+    jest.spyOn(require("react-relay"), "fetchQuery").mockImplementation(() => {
+      return {
+        toPromise: () => {
+          return { session: true };
+        },
+      };
+    });
+    jest
+      .spyOn(require("react-relay"), "useRelayEnvironment")
+      .mockImplementation(() => jest.fn());
+
+    let componentUnderTest;
+    act(() => {
+      componentUnderTest = render(
+        <SessionExpiryHandler></SessionExpiryHandler>
+      );
+    });
+
+    expect(componentUnderTest.container).toMatchSnapshot();
+    expect(mockSessionTimeoutHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't render the SessionTimeoutHandler component after the session expires", () => {});
+});


### PR DESCRIPTION
Small fix making sure the `SessionTimeoutHandler` component doesn't render after the session expires