### PR TITLE
chore: add PG env vars to operator-import cronjob

### DIFF
--- a/chart/cas-cif/templates/cronJobs/cron-swrs-operator-import.yaml
+++ b/chart/cas-cif/templates/cronJobs/cron-swrs-operator-import.yaml
@@ -22,6 +22,25 @@ spec:
           restartPolicy: Never
           containers:
             - env:
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-name
+                      name: {{ template "cas-cif.fullname" . }}
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-owner-user
+                      name: {{ template "cas-cif.fullname" . }}
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-owner-password
+                      name: {{ template "cas-cif.fullname" . }}
+                - name: PGPORT
+                  value: "5432"
+                - name: PGHOST
+                  value: {{ template "cas-cif.fullname" . }}-patroni
                 - name: GGIRCS_USER
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
original PR missing PG env vars for psql