### PR TITLE
chore: grant on cif database (not postgres)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ create_foreign_test_db:
 	@$(PSQL) -d postgres -tc "SELECT count(*) FROM pg_database WHERE datname = 'foreign_test_db'" | \
 		grep -q 1 || \
 		$(PSQL) -d postgres -c "CREATE DATABASE foreign_test_db" &&\
-		$(PSQL) -d foreign_test_db -f "./schema/data/test_setup/external_database_setup.sql";
+		$(PSQL) -d foreign_test_db -f "./schema/data/test_setup/external_database_setup.sql" &&\
+		$(PSQL) -d $(DB_NAME)_test -c "create extension if not exists postgres_fdw";
 
 .PHONY: drop_test_db
 drop_test_db: ## Drop the $(DB_NAME)_test database if it exists

--- a/chart/cas-cif/templates/cronJobs/db-init.yaml
+++ b/chart/cas-cif/templates/cronJobs/db-init.yaml
@@ -69,7 +69,7 @@ spec:
 {{ .Values.db.preInitCommand | indent 18 }}
                   create-user-db -d $(CIF_DATABASE) -u $(CIF_USER) -p $(CIF_PASSWORD) --owner;
                   alter-role $(CIF_USER) createrole;
-                  psql -v "ON_ERROR_STOP=1"<<EOF
+                  psql -d $(CIF_DATABASE) -v "ON_ERROR_STOP=1"<<EOF
                     create extension if not exists postgres_fdw;
                     grant usage on foreign data wrapper postgres_fdw to $(CIF_USER);
                   EOF

--- a/schema/deploy/util_functions/import_swrs_operators.sql
+++ b/schema/deploy/util_functions/import_swrs_operators.sql
@@ -4,8 +4,6 @@
 
 begin;
 
-create extension if not exists postgres_fdw;
-
 -- Creates a foreign table and imports the operators from the ggircs database into the operator table in the cif database.
 create or replace function cif_private.import_swrs_operators(
   ggircs_host text,


### PR DESCRIPTION
grant usage on postgres_fdw was being done on the wrong db (postgres)