### PR TITLE
Chore: project managers computed column

### DIFF
--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -4673,6 +4673,240 @@ type CifUser implements Node {
   ): CifUserCifUsersByProjectManagerCreatedByAndUpdatedByManyToManyConnection!
 
   """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerLabelArchivedByAndCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerLabelArchivedByAndUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerLabelCreatedByAndArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerLabelCreatedByAndUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerLabelUpdatedByAndArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerLabelUpdatedByAndCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
   cifUsersByProjectManagerUpdatedByAndArchivedBy(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
@@ -6598,6 +6832,279 @@ type CifUser implements Node {
     """The method to use when ordering `ProjectContact`."""
     orderBy: [ProjectContactsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProjectContactsConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = INHERIT
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = INHERIT
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = INHERIT
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
 
   """Reads and enables pagination through a set of `ProjectManager`."""
   projectManagersByArchivedBy(
@@ -12571,6 +13078,420 @@ type CifUserCifUsersByProjectManagerCreatedByAndUpdatedByManyToManyEdge {
 }
 
 """
+A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.
+"""
+type CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection!
+}
+
+"""
 A connection to a list of `CifUser` values, with data from `ProjectManager`.
 """
 type CifUserCifUsersByProjectManagerUpdatedByAndArchivedByManyToManyConnection {
@@ -13904,6 +14825,24 @@ input CifUserFilter {
   """Some related `projectContactsByUpdatedBy` exist."""
   projectContactsByUpdatedByExist: Boolean
 
+  """Filter by the object’s `projectManagerLabelsByArchivedBy` relation."""
+  projectManagerLabelsByArchivedBy: CifUserToManyProjectManagerLabelFilter
+
+  """Some related `projectManagerLabelsByArchivedBy` exist."""
+  projectManagerLabelsByArchivedByExist: Boolean
+
+  """Filter by the object’s `projectManagerLabelsByCreatedBy` relation."""
+  projectManagerLabelsByCreatedBy: CifUserToManyProjectManagerLabelFilter
+
+  """Some related `projectManagerLabelsByCreatedBy` exist."""
+  projectManagerLabelsByCreatedByExist: Boolean
+
+  """Filter by the object’s `projectManagerLabelsByUpdatedBy` relation."""
+  projectManagerLabelsByUpdatedBy: CifUserToManyProjectManagerLabelFilter
+
+  """Some related `projectManagerLabelsByUpdatedBy` exist."""
+  projectManagerLabelsByUpdatedByExist: Boolean
+
   """Filter by the object’s `projectManagersByArchivedBy` relation."""
   projectManagersByArchivedBy: CifUserToManyProjectManagerFilter
 
@@ -14887,6 +15826,290 @@ input CifUserPatch {
   Universally Unique ID for the user, defined by the single sign-on provider
   """
   uuid: UUID
+}
+
+"""
+A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyConnection {
+  """
+  A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyEdge!]!
+
+  """A list of `ProjectManagerLabel` objects."""
+  nodes: [ProjectManagerLabel]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ProjectManagerLabel` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProjectManagerLabel` at the end of the edge."""
+  node: ProjectManagerLabel
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyConnection {
+  """
+  A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyEdge!]!
+
+  """A list of `ProjectManagerLabel` objects."""
+  nodes: [ProjectManagerLabel]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ProjectManagerLabel` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProjectManagerLabel` at the end of the edge."""
+  node: ProjectManagerLabel
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyConnection {
+  """
+  A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyEdge!]!
+
+  """A list of `ProjectManagerLabel` objects."""
+  nodes: [ProjectManagerLabel]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ProjectManagerLabel` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProjectManagerLabel` at the end of the edge."""
+  node: ProjectManagerLabel
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyConnection {
+  """
+  A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyEdge!]!
+
+  """A list of `ProjectManagerLabel` objects."""
+  nodes: [ProjectManagerLabel]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ProjectManagerLabel` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.
+"""
+type CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProjectManagerLabel` at the end of the edge."""
+  node: ProjectManagerLabel
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
 }
 
 """
@@ -16289,6 +17512,26 @@ input CifUserToManyProjectManagerFilter {
 }
 
 """
+A filter to be used against many `ProjectManagerLabel` object types. All fields are combined with a logical ‘and.’
+"""
+input CifUserToManyProjectManagerLabelFilter {
+  """
+  Every related `ProjectManagerLabel` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ProjectManagerLabelFilter
+
+  """
+  No related `ProjectManagerLabel` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ProjectManagerLabelFilter
+
+  """
+  Some related `ProjectManagerLabel` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ProjectManagerLabelFilter
+}
+
+"""
 A filter to be used against many `ProjectRevision` object types. All fields are combined with a logical ‘and.’
 """
 input CifUserToManyProjectRevisionFilter {
@@ -16515,6 +17758,12 @@ enum CifUsersOrderBy {
   PROJECT_MANAGERS_BY_CREATED_BY__COUNT_DESC
   PROJECT_MANAGERS_BY_UPDATED_BY__COUNT_ASC
   PROJECT_MANAGERS_BY_UPDATED_BY__COUNT_DESC
+  PROJECT_MANAGER_LABELS_BY_ARCHIVED_BY__COUNT_ASC
+  PROJECT_MANAGER_LABELS_BY_ARCHIVED_BY__COUNT_DESC
+  PROJECT_MANAGER_LABELS_BY_CREATED_BY__COUNT_ASC
+  PROJECT_MANAGER_LABELS_BY_CREATED_BY__COUNT_DESC
+  PROJECT_MANAGER_LABELS_BY_UPDATED_BY__COUNT_ASC
+  PROJECT_MANAGER_LABELS_BY_UPDATED_BY__COUNT_DESC
   PROJECT_REVISIONS_BY_CREATED_BY__COUNT_ASC
   PROJECT_REVISIONS_BY_CREATED_BY__COUNT_DESC
   PROJECT_REVISIONS_BY_UPDATED_BY__COUNT_ASC
@@ -17763,6 +19012,56 @@ input CreateProjectManagerInput {
   projectManager: ProjectManagerInput!
 }
 
+"""All input for the create `ProjectManagerLabel` mutation."""
+input CreateProjectManagerLabelInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `ProjectManagerLabel` to be created by this mutation."""
+  projectManagerLabel: ProjectManagerLabelInput!
+}
+
+"""The output of our create `ProjectManagerLabel` mutation."""
+type CreateProjectManagerLabelPayload {
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByArchivedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByCreatedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByUpdatedBy: CifUser
+
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ProjectManagerLabel` that was created by this mutation."""
+  projectManagerLabel: ProjectManagerLabel
+
+  """An edge for our `ProjectManagerLabel`. May be used by Relay 1."""
+  projectManagerLabelEdge(
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """The output of our create `ProjectManager` mutation."""
 type CreateProjectManagerPayload {
   """Reads a single `CifUser` that is related to this `ProjectManager`."""
@@ -17794,6 +19093,11 @@ type CreateProjectManagerPayload {
     """The method to use when ordering `ProjectManager`."""
     orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProjectManagersEdge
+
+  """
+  Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.
+  """
+  projectManagerLabelByProjectManagerLabelId: ProjectManagerLabel
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -18552,6 +19856,71 @@ input DeleteProjectManagerInput {
   id: ID!
 }
 
+"""All input for the `deleteProjectManagerLabelByRowId` mutation."""
+input DeleteProjectManagerLabelByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """Unique ID for the project_manager_label record"""
+  rowId: Int!
+}
+
+"""All input for the `deleteProjectManagerLabel` mutation."""
+input DeleteProjectManagerLabelInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ProjectManagerLabel` to be deleted.
+  """
+  id: ID!
+}
+
+"""The output of our delete `ProjectManagerLabel` mutation."""
+type DeleteProjectManagerLabelPayload {
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByArchivedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByCreatedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByUpdatedBy: CifUser
+
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedProjectManagerLabelId: ID
+
+  """The `ProjectManagerLabel` that was deleted by this mutation."""
+  projectManagerLabel: ProjectManagerLabel
+
+  """An edge for our `ProjectManagerLabel`. May be used by Relay 1."""
+  projectManagerLabelEdge(
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """The output of our delete `ProjectManager` mutation."""
 type DeleteProjectManagerPayload {
   """Reads a single `CifUser` that is related to this `ProjectManager`."""
@@ -18584,6 +19953,11 @@ type DeleteProjectManagerPayload {
     """The method to use when ordering `ProjectManager`."""
     orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProjectManagersEdge
+
+  """
+  Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.
+  """
+  projectManagerLabelByProjectManagerLabelId: ProjectManagerLabel
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -21901,6 +23275,68 @@ input KeycloakJwtFilter {
 }
 
 """
+The type of change operation, defining the action taken when the form_change is committed.
+"""
+type ManagerFormChangesByLabelCompositeReturn {
+  formChangeId: Int
+  label: String
+  newFormData: JSON
+}
+
+"""
+A filter to be used against `ManagerFormChangesByLabelCompositeReturn` object types. All fields are combined with a logical ‘and.’
+"""
+input ManagerFormChangesByLabelCompositeReturnFilter {
+  """Checks for all expressions in this list."""
+  and: [ManagerFormChangesByLabelCompositeReturnFilter!]
+
+  """Filter by the object’s `formChangeId` field."""
+  formChangeId: IntFilter
+
+  """Filter by the object’s `label` field."""
+  label: StringFilter
+
+  """Filter by the object’s `newFormData` field."""
+  newFormData: JSONFilter
+
+  """Negates the expression."""
+  not: ManagerFormChangesByLabelCompositeReturnFilter
+
+  """Checks for any expressions in this list."""
+  or: [ManagerFormChangesByLabelCompositeReturnFilter!]
+}
+
+"""
+A connection to a list of `ManagerFormChangesByLabelCompositeReturn` values.
+"""
+type ManagerFormChangesByLabelCompositeReturnsConnection {
+  """
+  A list of edges which contains the `ManagerFormChangesByLabelCompositeReturn` and cursor to aid in pagination.
+  """
+  edges: [ManagerFormChangesByLabelCompositeReturnsEdge!]!
+
+  """A list of `ManagerFormChangesByLabelCompositeReturn` objects."""
+  nodes: [ManagerFormChangesByLabelCompositeReturn]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ManagerFormChangesByLabelCompositeReturn` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A `ManagerFormChangesByLabelCompositeReturn` edge in the connection."""
+type ManagerFormChangesByLabelCompositeReturnsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ManagerFormChangesByLabelCompositeReturn` at the end of the edge."""
+  node: ManagerFormChangesByLabelCompositeReturn
+}
+
+"""
 The root mutation type which contains root level fields which mutate data.
 """
 type Mutation {
@@ -21991,6 +23427,14 @@ type Mutation {
     """
     input: CreateProjectManagerInput!
   ): CreateProjectManagerPayload
+
+  """Creates a single `ProjectManagerLabel`."""
+  createProjectManagerLabel(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateProjectManagerLabelInput!
+  ): CreateProjectManagerLabelPayload
 
   """Creates a single `ProjectRevision`."""
   createProjectRevision(
@@ -22159,6 +23603,22 @@ type Mutation {
     """
     input: DeleteProjectManagerByRowIdInput!
   ): DeleteProjectManagerPayload
+
+  """Deletes a single `ProjectManagerLabel` using its globally unique id."""
+  deleteProjectManagerLabel(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProjectManagerLabelInput!
+  ): DeleteProjectManagerLabelPayload
+
+  """Deletes a single `ProjectManagerLabel` using a unique key."""
+  deleteProjectManagerLabelByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProjectManagerLabelByRowIdInput!
+  ): DeleteProjectManagerLabelPayload
 
   """Deletes a single `ProjectRevision` using its globally unique id."""
   deleteProjectRevision(
@@ -22353,6 +23813,24 @@ type Mutation {
     """
     input: UpdateProjectManagerByRowIdInput!
   ): UpdateProjectManagerPayload
+
+  """
+  Updates a single `ProjectManagerLabel` using its globally unique id and a patch.
+  """
+  updateProjectManagerLabel(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProjectManagerLabelInput!
+  ): UpdateProjectManagerLabelPayload
+
+  """Updates a single `ProjectManagerLabel` using a unique key and a patch."""
+  updateProjectManagerLabelByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProjectManagerLabelByRowIdInput!
+  ): UpdateProjectManagerLabelPayload
 
   """
   Updates a single `ProjectRevision` using its globally unique id and a patch.
@@ -23833,6 +25311,45 @@ type Project implements Node {
     orderBy: [ProjectContactsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProjectContactsConnection!
 
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  projectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyConnection!
+
   """Reads and enables pagination through a set of `ProjectManager`."""
   projectManagersByProjectId(
     """Read all values in the set after (below) this cursor."""
@@ -25252,6 +26769,16 @@ type ProjectManager implements Node {
   """Foreign key to the project"""
   projectId: Int!
 
+  """
+  Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.
+  """
+  projectManagerLabelByProjectManagerLabelId: ProjectManagerLabel
+
+  """
+  Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project
+  """
+  projectManagerLabelId: Int!
+
   """Unique ID for the project manager record"""
   rowId: Int!
 
@@ -25284,6 +26811,9 @@ input ProjectManagerCondition {
 
   """Checks for equality with the object’s `projectId` field."""
   projectId: Int
+
+  """Checks for equality with the object’s `projectManagerLabelId` field."""
+  projectManagerLabelId: Int
 
   """Checks for equality with the object’s `rowId` field."""
   rowId: Int
@@ -25350,6 +26880,14 @@ input ProjectManagerFilter {
   """Filter by the object’s `projectId` field."""
   projectId: IntFilter
 
+  """
+  Filter by the object’s `projectManagerLabelByProjectManagerLabelId` relation.
+  """
+  projectManagerLabelByProjectManagerLabelId: ProjectManagerLabelFilter
+
+  """Filter by the object’s `projectManagerLabelId` field."""
+  projectManagerLabelId: IntFilter
+
   """Filter by the object’s `rowId` field."""
   rowId: IntFilter
 
@@ -25380,11 +26918,917 @@ input ProjectManagerInput {
   """Foreign key to the project"""
   projectId: Int!
 
+  """
+  Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project
+  """
+  projectManagerLabelId: Int!
+
   """updated at timestamp"""
   updatedAt: Datetime
 
   """updated by user id"""
   updatedBy: Int
+}
+
+"""
+Lookup table for project manager labels. Records define the labels that project managers can be assigned to a project as
+"""
+type ProjectManagerLabel implements Node {
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByArchivedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByCreatedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByUpdatedBy: CifUser
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerProjectManagerLabelIdAndArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerProjectManagerLabelIdAndCifUserId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerProjectManagerLabelIdAndCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CifUser`."""
+  cifUsersByProjectManagerProjectManagerLabelIdAndUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CifUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CifUserFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `CifUser`."""
+    orderBy: [CifUsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyConnection!
+
+  """created at timestamp"""
+  createdAt: Datetime!
+
+  """created by user id"""
+  createdBy: Int
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  id: ID!
+
+  """The label that project managers can be assigned to a project as"""
+  label: String!
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = INHERIT
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+
+  """Reads and enables pagination through a set of `Project`."""
+  projectsByProjectManagerProjectManagerLabelIdAndProjectId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Project`."""
+    orderBy: [ProjectsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyConnection!
+
+  """Unique ID for the project_manager_label record"""
+  rowId: Int!
+
+  """updated at timestamp"""
+  updatedAt: Datetime!
+
+  """updated by user id"""
+  updatedBy: Int
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManager`.
+"""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `CifUser` edge in the connection, with data from `ProjectManager`."""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByArchivedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManager`.
+"""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `CifUser` edge in the connection, with data from `ProjectManager`."""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByCifUserId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManager`.
+"""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `CifUser` edge in the connection, with data from `ProjectManager`."""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByCreatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A connection to a list of `CifUser` values, with data from `ProjectManager`.
+"""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyConnection {
+  """
+  A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyEdge!]!
+
+  """A list of `CifUser` objects."""
+  nodes: [CifUser]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CifUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `CifUser` edge in the connection, with data from `ProjectManager`."""
+type ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CifUser` at the end of the edge."""
+  node: CifUser
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByUpdatedBy(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A condition to be used against `ProjectManagerLabel` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input ProjectManagerLabelCondition {
+  """Checks for equality with the object’s `archivedAt` field."""
+  archivedAt: Datetime
+
+  """Checks for equality with the object’s `archivedBy` field."""
+  archivedBy: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `createdBy` field."""
+  createdBy: Int
+
+  """Checks for equality with the object’s `label` field."""
+  label: String
+
+  """Checks for equality with the object’s `rowId` field."""
+  rowId: Int
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `updatedBy` field."""
+  updatedBy: Int
+}
+
+"""
+A filter to be used against `ProjectManagerLabel` object types. All fields are combined with a logical ‘and.’
+"""
+input ProjectManagerLabelFilter {
+  """Checks for all expressions in this list."""
+  and: [ProjectManagerLabelFilter!]
+
+  """Filter by the object’s `archivedAt` field."""
+  archivedAt: DatetimeFilter
+
+  """Filter by the object’s `archivedBy` field."""
+  archivedBy: IntFilter
+
+  """Filter by the object’s `cifUserByArchivedBy` relation."""
+  cifUserByArchivedBy: CifUserFilter
+
+  """A related `cifUserByArchivedBy` exists."""
+  cifUserByArchivedByExists: Boolean
+
+  """Filter by the object’s `cifUserByCreatedBy` relation."""
+  cifUserByCreatedBy: CifUserFilter
+
+  """A related `cifUserByCreatedBy` exists."""
+  cifUserByCreatedByExists: Boolean
+
+  """Filter by the object’s `cifUserByUpdatedBy` relation."""
+  cifUserByUpdatedBy: CifUserFilter
+
+  """A related `cifUserByUpdatedBy` exists."""
+  cifUserByUpdatedByExists: Boolean
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `createdBy` field."""
+  createdBy: IntFilter
+
+  """Filter by the object’s `label` field."""
+  label: StringFilter
+
+  """Negates the expression."""
+  not: ProjectManagerLabelFilter
+
+  """Checks for any expressions in this list."""
+  or: [ProjectManagerLabelFilter!]
+
+  """
+  Filter by the object’s `projectManagersByProjectManagerLabelId` relation.
+  """
+  projectManagersByProjectManagerLabelId: ProjectManagerLabelToManyProjectManagerFilter
+
+  """Some related `projectManagersByProjectManagerLabelId` exist."""
+  projectManagersByProjectManagerLabelIdExist: Boolean
+
+  """Filter by the object’s `rowId` field."""
+  rowId: IntFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `updatedBy` field."""
+  updatedBy: IntFilter
+}
+
+"""An input for mutations affecting `ProjectManagerLabel`"""
+input ProjectManagerLabelInput {
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """created by user id"""
+  createdBy: Int
+
+  """The label that project managers can be assigned to a project as"""
+  label: String!
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+}
+
+"""
+Represents an update to a `ProjectManagerLabel`. Fields that are set will be updated.
+"""
+input ProjectManagerLabelPatch {
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """created by user id"""
+  createdBy: Int
+
+  """The label that project managers can be assigned to a project as"""
+  label: String
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+}
+
+"""
+A connection to a list of `Project` values, with data from `ProjectManager`.
+"""
+type ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyConnection {
+  """
+  A list of edges which contains the `Project`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyEdge!]!
+
+  """A list of `Project` objects."""
+  nodes: [Project]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Project` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Project` edge in the connection, with data from `ProjectManager`."""
+type ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Project` at the end of the edge."""
+  node: Project
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
+}
+
+"""
+A filter to be used against many `ProjectManager` object types. All fields are combined with a logical ‘and.’
+"""
+input ProjectManagerLabelToManyProjectManagerFilter {
+  """
+  Every related `ProjectManager` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ProjectManagerFilter
+
+  """
+  No related `ProjectManager` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ProjectManagerFilter
+
+  """
+  Some related `ProjectManager` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ProjectManagerFilter
+}
+
+"""A connection to a list of `ProjectManagerLabel` values."""
+type ProjectManagerLabelsConnection {
+  """
+  A list of edges which contains the `ProjectManagerLabel` and cursor to aid in pagination.
+  """
+  edges: [ProjectManagerLabelsEdge!]!
+
+  """A list of `ProjectManagerLabel` objects."""
+  nodes: [ProjectManagerLabel]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ProjectManagerLabel` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A `ProjectManagerLabel` edge in the connection."""
+type ProjectManagerLabelsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProjectManagerLabel` at the end of the edge."""
+  node: ProjectManagerLabel
+}
+
+"""Methods to use when ordering `ProjectManagerLabel`."""
+enum ProjectManagerLabelsOrderBy {
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  ARCHIVED_BY_ASC
+  ARCHIVED_BY_DESC
+  CIF_USER_BY_ARCHIVED_BY__ARCHIVED_AT_ASC
+  CIF_USER_BY_ARCHIVED_BY__ARCHIVED_AT_DESC
+  CIF_USER_BY_ARCHIVED_BY__ARCHIVED_BY_ASC
+  CIF_USER_BY_ARCHIVED_BY__ARCHIVED_BY_DESC
+  CIF_USER_BY_ARCHIVED_BY__CREATED_AT_ASC
+  CIF_USER_BY_ARCHIVED_BY__CREATED_AT_DESC
+  CIF_USER_BY_ARCHIVED_BY__CREATED_BY_ASC
+  CIF_USER_BY_ARCHIVED_BY__CREATED_BY_DESC
+  CIF_USER_BY_ARCHIVED_BY__EMAIL_ADDRESS_ASC
+  CIF_USER_BY_ARCHIVED_BY__EMAIL_ADDRESS_DESC
+  CIF_USER_BY_ARCHIVED_BY__FIRST_NAME_ASC
+  CIF_USER_BY_ARCHIVED_BY__FIRST_NAME_DESC
+  CIF_USER_BY_ARCHIVED_BY__ID_ASC
+  CIF_USER_BY_ARCHIVED_BY__ID_DESC
+  CIF_USER_BY_ARCHIVED_BY__LAST_NAME_ASC
+  CIF_USER_BY_ARCHIVED_BY__LAST_NAME_DESC
+  CIF_USER_BY_ARCHIVED_BY__UPDATED_AT_ASC
+  CIF_USER_BY_ARCHIVED_BY__UPDATED_AT_DESC
+  CIF_USER_BY_ARCHIVED_BY__UPDATED_BY_ASC
+  CIF_USER_BY_ARCHIVED_BY__UPDATED_BY_DESC
+  CIF_USER_BY_ARCHIVED_BY__UUID_ASC
+  CIF_USER_BY_ARCHIVED_BY__UUID_DESC
+  CIF_USER_BY_CREATED_BY__ARCHIVED_AT_ASC
+  CIF_USER_BY_CREATED_BY__ARCHIVED_AT_DESC
+  CIF_USER_BY_CREATED_BY__ARCHIVED_BY_ASC
+  CIF_USER_BY_CREATED_BY__ARCHIVED_BY_DESC
+  CIF_USER_BY_CREATED_BY__CREATED_AT_ASC
+  CIF_USER_BY_CREATED_BY__CREATED_AT_DESC
+  CIF_USER_BY_CREATED_BY__CREATED_BY_ASC
+  CIF_USER_BY_CREATED_BY__CREATED_BY_DESC
+  CIF_USER_BY_CREATED_BY__EMAIL_ADDRESS_ASC
+  CIF_USER_BY_CREATED_BY__EMAIL_ADDRESS_DESC
+  CIF_USER_BY_CREATED_BY__FIRST_NAME_ASC
+  CIF_USER_BY_CREATED_BY__FIRST_NAME_DESC
+  CIF_USER_BY_CREATED_BY__ID_ASC
+  CIF_USER_BY_CREATED_BY__ID_DESC
+  CIF_USER_BY_CREATED_BY__LAST_NAME_ASC
+  CIF_USER_BY_CREATED_BY__LAST_NAME_DESC
+  CIF_USER_BY_CREATED_BY__UPDATED_AT_ASC
+  CIF_USER_BY_CREATED_BY__UPDATED_AT_DESC
+  CIF_USER_BY_CREATED_BY__UPDATED_BY_ASC
+  CIF_USER_BY_CREATED_BY__UPDATED_BY_DESC
+  CIF_USER_BY_CREATED_BY__UUID_ASC
+  CIF_USER_BY_CREATED_BY__UUID_DESC
+  CIF_USER_BY_UPDATED_BY__ARCHIVED_AT_ASC
+  CIF_USER_BY_UPDATED_BY__ARCHIVED_AT_DESC
+  CIF_USER_BY_UPDATED_BY__ARCHIVED_BY_ASC
+  CIF_USER_BY_UPDATED_BY__ARCHIVED_BY_DESC
+  CIF_USER_BY_UPDATED_BY__CREATED_AT_ASC
+  CIF_USER_BY_UPDATED_BY__CREATED_AT_DESC
+  CIF_USER_BY_UPDATED_BY__CREATED_BY_ASC
+  CIF_USER_BY_UPDATED_BY__CREATED_BY_DESC
+  CIF_USER_BY_UPDATED_BY__EMAIL_ADDRESS_ASC
+  CIF_USER_BY_UPDATED_BY__EMAIL_ADDRESS_DESC
+  CIF_USER_BY_UPDATED_BY__FIRST_NAME_ASC
+  CIF_USER_BY_UPDATED_BY__FIRST_NAME_DESC
+  CIF_USER_BY_UPDATED_BY__ID_ASC
+  CIF_USER_BY_UPDATED_BY__ID_DESC
+  CIF_USER_BY_UPDATED_BY__LAST_NAME_ASC
+  CIF_USER_BY_UPDATED_BY__LAST_NAME_DESC
+  CIF_USER_BY_UPDATED_BY__UPDATED_AT_ASC
+  CIF_USER_BY_UPDATED_BY__UPDATED_AT_DESC
+  CIF_USER_BY_UPDATED_BY__UPDATED_BY_ASC
+  CIF_USER_BY_UPDATED_BY__UPDATED_BY_DESC
+  CIF_USER_BY_UPDATED_BY__UUID_ASC
+  CIF_USER_BY_UPDATED_BY__UUID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  CREATED_BY_ASC
+  CREATED_BY_DESC
+  ID_ASC
+  ID_DESC
+  LABEL_ASC
+  LABEL_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROJECT_MANAGERS_BY_PROJECT_MANAGER_LABEL_ID__COUNT_ASC
+  PROJECT_MANAGERS_BY_PROJECT_MANAGER_LABEL_ID__COUNT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  UPDATED_BY_ASC
+  UPDATED_BY_DESC
 }
 
 """
@@ -25408,6 +27852,11 @@ input ProjectManagerPatch {
 
   """Foreign key to the project"""
   projectId: Int
+
+  """
+  Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project
+  """
+  projectManagerLabelId: Int
 
   """updated at timestamp"""
   updatedAt: Datetime
@@ -25577,10 +28026,99 @@ enum ProjectManagersOrderBy {
   PROJECT_BY_PROJECT_ID__UPDATED_BY_DESC
   PROJECT_ID_ASC
   PROJECT_ID_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_AT_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_AT_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_BY_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_BY_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_AT_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_AT_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_BY_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_BY_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ID_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ID_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__LABEL_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__LABEL_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_AT_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_AT_DESC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_BY_ASC
+  PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_BY_DESC
+  PROJECT_MANAGER_LABEL_ID_ASC
+  PROJECT_MANAGER_LABEL_ID_DESC
   UPDATED_AT_ASC
   UPDATED_AT_DESC
   UPDATED_BY_ASC
   UPDATED_BY_DESC
+}
+
+"""
+A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.
+"""
+type ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyConnection {
+  """
+  A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.
+  """
+  edges: [ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyEdge!]!
+
+  """A list of `ProjectManagerLabel` objects."""
+  nodes: [ProjectManagerLabel]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ProjectManagerLabel` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.
+"""
+type ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProjectManagerLabel` at the end of the edge."""
+  node: ProjectManagerLabel
+
+  """Reads and enables pagination through a set of `ProjectManager`."""
+  projectManagersByProjectManagerLabelId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManager`."""
+    orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagersConnection!
 }
 
 """Table containing all the changes for a project revision"""
@@ -25774,6 +28312,34 @@ type ProjectRevision implements Node {
   """
   projectId: Int
   projectManagerFormChange: FormChange
+
+  """
+  Computed column returns a composite value for each record in project_manager_label and the last related form_change if it exists
+  """
+  projectManagerFormChangesByLabel(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ManagerFormChangesByLabelCompositeReturnFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): ManagerFormChangesByLabelCompositeReturnsConnection!
 
   """Unique ID for the project revision"""
   rowId: Int!
@@ -28331,6 +30897,45 @@ type Query implements Node {
     orderBy: [ProjectContactsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProjectContactsConnection
 
+  """Reads and enables pagination through a set of `ProjectManagerLabel`."""
+  allProjectManagerLabels(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProjectManagerLabelCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ProjectManagerLabelFilter
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Indicates whether archived items should be included in the results or not.
+    """
+    includeArchived: IncludeArchivedOption = NO
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsConnection
+
   """Reads and enables pagination through a set of `ProjectManager`."""
   allProjectManagers(
     """Read all values in the set after (below) this cursor."""
@@ -28606,6 +31211,15 @@ type Query implements Node {
     id: ID!
   ): ProjectManager
   projectManagerByRowId(rowId: Int!): ProjectManager
+
+  """Reads a single `ProjectManagerLabel` using its globally unique `ID`."""
+  projectManagerLabel(
+    """
+    The globally unique `ID` to be used in selecting a single `ProjectManagerLabel`.
+    """
+    id: ID!
+  ): ProjectManagerLabel
+  projectManagerLabelByRowId(rowId: Int!): ProjectManagerLabel
 
   """Reads a single `ProjectRevision` using its globally unique `ID`."""
   projectRevision(
@@ -29489,6 +32103,80 @@ input UpdateProjectManagerInput {
   projectManagerPatch: ProjectManagerPatch!
 }
 
+"""All input for the `updateProjectManagerLabelByRowId` mutation."""
+input UpdateProjectManagerLabelByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `ProjectManagerLabel` being updated.
+  """
+  projectManagerLabelPatch: ProjectManagerLabelPatch!
+
+  """Unique ID for the project_manager_label record"""
+  rowId: Int!
+}
+
+"""All input for the `updateProjectManagerLabel` mutation."""
+input UpdateProjectManagerLabelInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ProjectManagerLabel` to be updated.
+  """
+  id: ID!
+
+  """
+  An object where the defined keys will be set on the `ProjectManagerLabel` being updated.
+  """
+  projectManagerLabelPatch: ProjectManagerLabelPatch!
+}
+
+"""The output of our update `ProjectManagerLabel` mutation."""
+type UpdateProjectManagerLabelPayload {
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByArchivedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByCreatedBy: CifUser
+
+  """
+  Reads a single `CifUser` that is related to this `ProjectManagerLabel`.
+  """
+  cifUserByUpdatedBy: CifUser
+
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ProjectManagerLabel` that was updated by this mutation."""
+  projectManagerLabel: ProjectManagerLabel
+
+  """An edge for our `ProjectManagerLabel`. May be used by Relay 1."""
+  projectManagerLabelEdge(
+    """The method to use when ordering `ProjectManagerLabel`."""
+    orderBy: [ProjectManagerLabelsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProjectManagerLabelsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """The output of our update `ProjectManager` mutation."""
 type UpdateProjectManagerPayload {
   """Reads a single `CifUser` that is related to this `ProjectManager`."""
@@ -29520,6 +32208,11 @@ type UpdateProjectManagerPayload {
     """The method to use when ordering `ProjectManager`."""
     orderBy: [ProjectManagersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProjectManagersEdge
+
+  """
+  Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.
+  """
+  projectManagerLabelByProjectManagerLabelId: ProjectManagerLabel
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -19856,6 +19856,18 @@ input DeleteProjectManagerInput {
   id: ID!
 }
 
+"""All input for the `deleteProjectManagerLabelByLabel` mutation."""
+input DeleteProjectManagerLabelByLabelInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The label that project managers can be assigned to a project as"""
+  label: String!
+}
+
 """All input for the `deleteProjectManagerLabelByRowId` mutation."""
 input DeleteProjectManagerLabelByRowIdInput {
   """
@@ -23278,9 +23290,8 @@ input KeycloakJwtFilter {
 The type of change operation, defining the action taken when the form_change is committed.
 """
 type ManagerFormChangesByLabelCompositeReturn {
-  formChangeId: Int
+  formChange: FormChange
   label: String
-  newFormData: JSON
 }
 
 """
@@ -23290,14 +23301,8 @@ input ManagerFormChangesByLabelCompositeReturnFilter {
   """Checks for all expressions in this list."""
   and: [ManagerFormChangesByLabelCompositeReturnFilter!]
 
-  """Filter by the object’s `formChangeId` field."""
-  formChangeId: IntFilter
-
   """Filter by the object’s `label` field."""
   label: StringFilter
-
-  """Filter by the object’s `newFormData` field."""
-  newFormData: JSONFilter
 
   """Negates the expression."""
   not: ManagerFormChangesByLabelCompositeReturnFilter
@@ -23613,6 +23618,14 @@ type Mutation {
   ): DeleteProjectManagerLabelPayload
 
   """Deletes a single `ProjectManagerLabel` using a unique key."""
+  deleteProjectManagerLabelByLabel(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProjectManagerLabelByLabelInput!
+  ): DeleteProjectManagerLabelPayload
+
+  """Deletes a single `ProjectManagerLabel` using a unique key."""
   deleteProjectManagerLabelByRowId(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -23822,6 +23835,14 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
     input: UpdateProjectManagerLabelInput!
+  ): UpdateProjectManagerLabelPayload
+
+  """Updates a single `ProjectManagerLabel` using a unique key and a patch."""
+  updateProjectManagerLabelByLabel(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProjectManagerLabelByLabelInput!
   ): UpdateProjectManagerLabelPayload
 
   """Updates a single `ProjectManagerLabel` using a unique key and a patch."""
@@ -31219,6 +31240,7 @@ type Query implements Node {
     """
     id: ID!
   ): ProjectManagerLabel
+  projectManagerLabelByLabel(label: String!): ProjectManagerLabel
   projectManagerLabelByRowId(rowId: Int!): ProjectManagerLabel
 
   """Reads a single `ProjectRevision` using its globally unique `ID`."""
@@ -32101,6 +32123,23 @@ input UpdateProjectManagerInput {
   An object where the defined keys will be set on the `ProjectManager` being updated.
   """
   projectManagerPatch: ProjectManagerPatch!
+}
+
+"""All input for the `updateProjectManagerLabelByLabel` mutation."""
+input UpdateProjectManagerLabelByLabelInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The label that project managers can be assigned to a project as"""
+  label: String!
+
+  """
+  An object where the defined keys will be set on the `ProjectManagerLabel` being updated.
+  """
+  projectManagerLabelPatch: ProjectManagerLabelPatch!
 }
 
 """All input for the `updateProjectManagerLabelByRowId` mutation."""

--- a/app/schema/schema.json
+++ b/app/schema/schema.json
@@ -14949,6 +14949,696 @@
               "deprecationReason": null
             },
             {
+              "name": "cifUsersByProjectManagerLabelArchivedByAndCreatedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerLabelArchivedByAndUpdatedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerLabelCreatedByAndArchivedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerLabelCreatedByAndUpdatedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerLabelUpdatedByAndArchivedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerLabelUpdatedByAndCreatedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "cifUsersByProjectManagerUpdatedByAndArchivedBy",
               "description": "Reads and enables pagination through a set of `CifUser`.",
               "args": [
@@ -20637,6 +21327,811 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ProjectContactsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByArchivedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "INHERIT"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByCreatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "INHERIT"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByUpdatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "INHERIT"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
                   "ofType": null
                 }
               },
@@ -41253,6 +42748,1428 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndCreatedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByCreatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelArchivedByAndUpdatedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByUpdatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndArchivedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByArchivedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelCreatedByAndUpdatedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByUpdatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndArchivedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByArchivedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManagerLabel`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserCifUsersByProjectManagerLabelUpdatedByAndCreatedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManagerLabel`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByCreatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "CifUserCifUsersByProjectManagerUpdatedByAndArchivedByManyToManyConnection",
           "description": "A connection to a list of `CifUser` values, with data from `ProjectManager`.",
           "fields": [
@@ -45927,6 +48844,66 @@
               "defaultValue": null
             },
             {
+              "name": "projectManagerLabelsByArchivedBy",
+              "description": "Filter by the object’s `projectManagerLabelsByArchivedBy` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CifUserToManyProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelsByArchivedByExist",
+              "description": "Some related `projectManagerLabelsByArchivedBy` exist.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelsByCreatedBy",
+              "description": "Filter by the object’s `projectManagerLabelsByCreatedBy` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CifUserToManyProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelsByCreatedByExist",
+              "description": "Some related `projectManagerLabelsByCreatedBy` exist.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelsByUpdatedBy",
+              "description": "Filter by the object’s `projectManagerLabelsByUpdatedBy` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CifUserToManyProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelsByUpdatedByExist",
+              "description": "Some related `projectManagerLabelsByUpdatedBy` exist.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "projectManagersByArchivedBy",
               "description": "Filter by the object’s `projectManagersByArchivedBy` relation.",
               "type": {
@@ -49278,6 +52255,954 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyConnection",
+          "description": "A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ProjectManagerLabel` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectManagerLabel",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ProjectManagerLabel` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerArchivedByAndProjectManagerLabelIdManyToManyEdge",
+          "description": "A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ProjectManagerLabel` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyConnection",
+          "description": "A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ProjectManagerLabel` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectManagerLabel",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ProjectManagerLabel` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerCifUserIdAndProjectManagerLabelIdManyToManyEdge",
+          "description": "A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ProjectManagerLabel` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyConnection",
+          "description": "A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ProjectManagerLabel` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectManagerLabel",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ProjectManagerLabel` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerCreatedByAndProjectManagerLabelIdManyToManyEdge",
+          "description": "A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ProjectManagerLabel` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyConnection",
+          "description": "A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ProjectManagerLabel` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectManagerLabel",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ProjectManagerLabel` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CifUserProjectManagerLabelsByProjectManagerUpdatedByAndProjectManagerLabelIdManyToManyEdge",
+          "description": "A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ProjectManagerLabel` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -53805,6 +57730,47 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "CifUserToManyProjectManagerLabelFilter",
+          "description": "A filter to be used against many `ProjectManagerLabel` object types. All fields are combined with a logical ‘and.’",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "every",
+              "description": "Every related `ProjectManagerLabel` matches the filter criteria. All fields are combined with a logical ‘and.’",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "none",
+              "description": "No related `ProjectManagerLabel` matches the filter criteria. All fields are combined with a logical ‘and.’",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "some",
+              "description": "Some related `ProjectManagerLabel` matches the filter criteria. All fields are combined with a logical ‘and.’",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "CifUserToManyProjectRevisionFilter",
           "description": "A filter to be used against many `ProjectRevision` object types. All fields are combined with a logical ‘and.’",
           "fields": null,
@@ -54965,6 +58931,42 @@
             },
             {
               "name": "PROJECT_MANAGERS_BY_UPDATED_BY__COUNT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABELS_BY_ARCHIVED_BY__COUNT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABELS_BY_ARCHIVED_BY__COUNT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABELS_BY_CREATED_BY__COUNT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABELS_BY_CREATED_BY__COUNT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABELS_BY_UPDATED_BY__COUNT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABELS_BY_UPDATED_BY__COUNT_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -59543,6 +63545,155 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateProjectManagerLabelInput",
+          "description": "All input for the create `ProjectManagerLabel` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabel",
+              "description": "The `ProjectManagerLabel` to be created by this mutation.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectManagerLabelInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateProjectManagerLabelPayload",
+          "description": "The output of our create `ProjectManagerLabel` mutation.",
+          "fields": [
+            {
+              "name": "cifUserByArchivedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByCreatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByUpdatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "The exact same `clientMutationId` that was provided in the mutation input,\nunchanged and unused. May be used by a client to track mutations.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabel",
+              "description": "The `ProjectManagerLabel` that was created by this mutation.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelEdge",
+              "description": "An edge for our `ProjectManagerLabel`. May be used by Relay 1.",
+              "args": [
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabelsEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "query",
+              "description": "Our root query field type. Allows us to run any query from our mutation payload.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Query",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "CreateProjectManagerPayload",
           "description": "The output of our create `ProjectManager` mutation.",
@@ -59657,6 +63808,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ProjectManagersEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelByProjectManagerLabelId",
+              "description": "Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -62119,6 +66282,202 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "DeleteProjectManagerLabelByRowIdInput",
+          "description": "All input for the `deleteProjectManagerLabelByRowId` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rowId",
+              "description": "Unique ID for the project_manager_label record",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeleteProjectManagerLabelInput",
+          "description": "All input for the `deleteProjectManagerLabel` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": "The globally unique `ID` which will identify a single `ProjectManagerLabel` to be deleted.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DeleteProjectManagerLabelPayload",
+          "description": "The output of our delete `ProjectManagerLabel` mutation.",
+          "fields": [
+            {
+              "name": "cifUserByArchivedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByCreatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByUpdatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "The exact same `clientMutationId` that was provided in the mutation input,\nunchanged and unused. May be used by a client to track mutations.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deletedProjectManagerLabelId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabel",
+              "description": "The `ProjectManagerLabel` that was deleted by this mutation.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelEdge",
+              "description": "An edge for our `ProjectManagerLabel`. May be used by Relay 1.",
+              "args": [
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabelsEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "query",
+              "description": "Our root query field type. Allows us to run any query from our mutation payload.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Query",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "DeleteProjectManagerPayload",
           "description": "The output of our delete `ProjectManager` mutation.",
@@ -62245,6 +66604,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ProjectManagersEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelByProjectManagerLabelId",
+              "description": "Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -74712,6 +79083,262 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ManagerFormChangesByLabelCompositeReturn",
+          "description": "The type of change operation, defining the action taken when the form_change is committed.",
+          "fields": [
+            {
+              "name": "formChangeId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "newFormData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ManagerFormChangesByLabelCompositeReturnFilter",
+          "description": "A filter to be used against `ManagerFormChangesByLabelCompositeReturn` object types. All fields are combined with a logical ‘and.’",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "and",
+              "description": "Checks for all expressions in this list.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ManagerFormChangesByLabelCompositeReturnFilter",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "formChangeId",
+              "description": "Filter by the object’s `formChangeId` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "Filter by the object’s `label` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "StringFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "newFormData",
+              "description": "Filter by the object’s `newFormData` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "JSONFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "not",
+              "description": "Negates the expression.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ManagerFormChangesByLabelCompositeReturnFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "or",
+              "description": "Checks for any expressions in this list.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ManagerFormChangesByLabelCompositeReturnFilter",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ManagerFormChangesByLabelCompositeReturnsConnection",
+          "description": "A connection to a list of `ManagerFormChangesByLabelCompositeReturn` values.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ManagerFormChangesByLabelCompositeReturn` and cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ManagerFormChangesByLabelCompositeReturnsEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ManagerFormChangesByLabelCompositeReturn` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ManagerFormChangesByLabelCompositeReturn",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ManagerFormChangesByLabelCompositeReturn` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ManagerFormChangesByLabelCompositeReturnsEdge",
+          "description": "A `ManagerFormChangesByLabelCompositeReturn` edge in the connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ManagerFormChangesByLabelCompositeReturn` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ManagerFormChangesByLabelCompositeReturn",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Mutation",
           "description": "The root mutation type which contains root level fields which mutate data.",
           "fields": [
@@ -75007,6 +79634,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CreateProjectManagerPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createProjectManagerLabel",
+              "description": "Creates a single `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateProjectManagerLabelInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateProjectManagerLabelPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -75574,6 +80228,60 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "DeleteProjectManagerPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteProjectManagerLabel",
+              "description": "Deletes a single `ProjectManagerLabel` using its globally unique id.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeleteProjectManagerLabelInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DeleteProjectManagerLabelPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteProjectManagerLabelByRowId",
+              "description": "Deletes a single `ProjectManagerLabel` using a unique key.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeleteProjectManagerLabelByRowIdInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DeleteProjectManagerLabelPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -76174,6 +80882,60 @@
               "deprecationReason": null
             },
             {
+              "name": "updateProjectManagerLabel",
+              "description": "Updates a single `ProjectManagerLabel` using its globally unique id and a patch.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateProjectManagerLabelInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateProjectManagerLabelPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateProjectManagerLabelByRowId",
+              "description": "Updates a single `ProjectManagerLabel` using a unique key and a patch.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateProjectManagerLabelByRowIdInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateProjectManagerLabelPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updateProjectRevision",
               "description": "Updates a single `ProjectRevision` using its globally unique id and a patch.",
               "args": [
@@ -76371,6 +81133,11 @@
             {
               "kind": "OBJECT",
               "name": "ProjectManager",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ProjectManagerLabel",
               "ofType": null
             },
             {
@@ -81316,6 +86083,121 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ProjectContactsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyConnection",
                   "ofType": null
                 }
               },
@@ -86753,6 +91635,34 @@
               "deprecationReason": null
             },
             {
+              "name": "projectManagerLabelByProjectManagerLabelId",
+              "description": "Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelId",
+              "description": "Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rowId",
               "description": "Unique ID for the project manager record",
               "args": [],
@@ -86867,6 +91777,16 @@
             {
               "name": "projectId",
               "description": "Checks for equality with the object’s `projectId` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelId",
+              "description": "Checks for equality with the object’s `projectManagerLabelId` field.",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
@@ -87102,6 +92022,26 @@
               "defaultValue": null
             },
             {
+              "name": "projectManagerLabelByProjectManagerLabelId",
+              "description": "Filter by the object’s `projectManagerLabelByProjectManagerLabelId` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelId",
+              "description": "Filter by the object’s `projectManagerLabelId` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "rowId",
               "description": "Filter by the object’s `rowId` field.",
               "type": {
@@ -87211,6 +92151,20 @@
               "defaultValue": null
             },
             {
+              "name": "projectManagerLabelId",
+              "description": "Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "updatedAt",
               "description": "updated at timestamp",
               "type": {
@@ -87233,6 +92187,3232 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabel",
+          "description": "Lookup table for project manager labels. Records define the labels that project managers can be assigned to a project as",
+          "fields": [
+            {
+              "name": "archivedAt",
+              "description": "archived at timestamp",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "archivedBy",
+              "description": "archived by user id",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByArchivedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByCreatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByUpdatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerProjectManagerLabelIdAndArchivedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerProjectManagerLabelIdAndCifUserId",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerProjectManagerLabelIdAndCreatedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUsersByProjectManagerProjectManagerLabelIdAndUpdatedBy",
+              "description": "Reads and enables pagination through a set of `CifUser`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CifUserFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `CifUser`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CifUsersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "created at timestamp",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Datetime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdBy",
+              "description": "created by user id",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": "The label that project managers can be assigned to a project as",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "INHERIT"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectsByProjectManagerProjectManagerLabelIdAndProjectId",
+              "description": "Reads and enables pagination through a set of `Project`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `Project`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rowId",
+              "description": "Unique ID for the project_manager_label record",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "updated at timestamp",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Datetime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedBy",
+              "description": "updated by user id",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndArchivedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByArchivedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCifUserIdManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByCifUserId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndCreatedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByCreatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyConnection",
+          "description": "A connection to a list of `CifUser` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `CifUser`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `CifUser` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CifUser",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `CifUser` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelCifUsersByProjectManagerProjectManagerLabelIdAndUpdatedByManyToManyEdge",
+          "description": "A `CifUser` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `CifUser` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByUpdatedBy",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProjectManagerLabelCondition",
+          "description": "A condition to be used against `ProjectManagerLabel` object types. All fields\nare tested for equality and combined with a logical ‘and.’",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "archivedAt",
+              "description": "Checks for equality with the object’s `archivedAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "archivedBy",
+              "description": "Checks for equality with the object’s `archivedBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdAt",
+              "description": "Checks for equality with the object’s `createdAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdBy",
+              "description": "Checks for equality with the object’s `createdBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "Checks for equality with the object’s `label` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rowId",
+              "description": "Checks for equality with the object’s `rowId` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "Checks for equality with the object’s `updatedAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedBy",
+              "description": "Checks for equality with the object’s `updatedBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProjectManagerLabelFilter",
+          "description": "A filter to be used against `ProjectManagerLabel` object types. All fields are combined with a logical ‘and.’",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "and",
+              "description": "Checks for all expressions in this list.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "archivedAt",
+              "description": "Filter by the object’s `archivedAt` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "DatetimeFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "archivedBy",
+              "description": "Filter by the object’s `archivedBy` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cifUserByArchivedBy",
+              "description": "Filter by the object’s `cifUserByArchivedBy` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CifUserFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cifUserByArchivedByExists",
+              "description": "A related `cifUserByArchivedBy` exists.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cifUserByCreatedBy",
+              "description": "Filter by the object’s `cifUserByCreatedBy` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CifUserFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cifUserByCreatedByExists",
+              "description": "A related `cifUserByCreatedBy` exists.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cifUserByUpdatedBy",
+              "description": "Filter by the object’s `cifUserByUpdatedBy` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CifUserFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cifUserByUpdatedByExists",
+              "description": "A related `cifUserByUpdatedBy` exists.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdAt",
+              "description": "Filter by the object’s `createdAt` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "DatetimeFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdBy",
+              "description": "Filter by the object’s `createdBy` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "Filter by the object’s `label` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "StringFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "not",
+              "description": "Negates the expression.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerLabelFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "or",
+              "description": "Checks for any expressions in this list.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Filter by the object’s `projectManagersByProjectManagerLabelId` relation.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerLabelToManyProjectManagerFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelIdExist",
+              "description": "Some related `projectManagersByProjectManagerLabelId` exist.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rowId",
+              "description": "Filter by the object’s `rowId` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "Filter by the object’s `updatedAt` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "DatetimeFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedBy",
+              "description": "Filter by the object’s `updatedBy` field.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProjectManagerLabelInput",
+          "description": "An input for mutations affecting `ProjectManagerLabel`",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "archivedAt",
+              "description": "archived at timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "archivedBy",
+              "description": "archived by user id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdAt",
+              "description": "created at timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdBy",
+              "description": "created by user id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "The label that project managers can be assigned to a project as",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "updated at timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedBy",
+              "description": "updated by user id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProjectManagerLabelPatch",
+          "description": "Represents an update to a `ProjectManagerLabel`. Fields that are set will be updated.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "archivedAt",
+              "description": "archived at timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "archivedBy",
+              "description": "archived by user id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdAt",
+              "description": "created at timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdBy",
+              "description": "created by user id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "The label that project managers can be assigned to a project as",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "updated at timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedBy",
+              "description": "updated by user id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyConnection",
+          "description": "A connection to a list of `Project` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `Project`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `Project` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Project",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `Project` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelProjectsByProjectManagerProjectManagerLabelIdAndProjectIdManyToManyEdge",
+          "description": "A `Project` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `Project` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProjectManagerLabelToManyProjectManagerFilter",
+          "description": "A filter to be used against many `ProjectManager` object types. All fields are combined with a logical ‘and.’",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "every",
+              "description": "Every related `ProjectManager` matches the filter criteria. All fields are combined with a logical ‘and.’",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "none",
+              "description": "No related `ProjectManager` matches the filter criteria. All fields are combined with a logical ‘and.’",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "some",
+              "description": "Some related `ProjectManager` matches the filter criteria. All fields are combined with a logical ‘and.’",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectManagerFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelsConnection",
+          "description": "A connection to a list of `ProjectManagerLabel` values.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ProjectManagerLabel` and cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectManagerLabelsEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ProjectManagerLabel` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectManagerLabel",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ProjectManagerLabel` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectManagerLabelsEdge",
+          "description": "A `ProjectManagerLabel` edge in the connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ProjectManagerLabel` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProjectManagerLabelsOrderBy",
+          "description": "Methods to use when ordering `ProjectManagerLabel`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ARCHIVED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARCHIVED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARCHIVED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARCHIVED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__ARCHIVED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__ARCHIVED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__ARCHIVED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__ARCHIVED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__CREATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__CREATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__CREATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__CREATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__EMAIL_ADDRESS_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__EMAIL_ADDRESS_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__FIRST_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__FIRST_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__LAST_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__LAST_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__UPDATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__UPDATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__UUID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_ARCHIVED_BY__UUID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__ARCHIVED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__ARCHIVED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__ARCHIVED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__ARCHIVED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__CREATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__CREATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__CREATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__CREATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__EMAIL_ADDRESS_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__EMAIL_ADDRESS_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__FIRST_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__FIRST_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__LAST_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__LAST_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__UPDATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__UPDATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__UUID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_CREATED_BY__UUID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__ARCHIVED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__ARCHIVED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__ARCHIVED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__ARCHIVED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__CREATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__CREATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__CREATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__CREATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__EMAIL_ADDRESS_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__EMAIL_ADDRESS_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__FIRST_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__FIRST_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__LAST_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__LAST_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__UPDATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__UPDATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__UUID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CIF_USER_BY_UPDATED_BY__UUID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LABEL_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LABEL_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NATURAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRIMARY_KEY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRIMARY_KEY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGERS_BY_PROJECT_MANAGER_LABEL_ID__COUNT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGERS_BY_PROJECT_MANAGER_LABEL_ID__COUNT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -87294,6 +95474,16 @@
             {
               "name": "projectId",
               "description": "Foreign key to the project",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelId",
+              "description": "Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
@@ -88255,6 +96445,114 @@
               "deprecationReason": null
             },
             {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ARCHIVED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__CREATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__LABEL_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__LABEL_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_BY_PROJECT_MANAGER_LABEL_ID__UPDATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT_MANAGER_LABEL_ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "UPDATED_AT_ASC",
               "description": null,
               "isDeprecated": false,
@@ -88279,6 +96577,243 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyConnection",
+          "description": "A connection to a list of `ProjectManagerLabel` values, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges which contains the `ProjectManagerLabel`, info from the `ProjectManager`, and the cursor to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of `ProjectManagerLabel` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectManagerLabel",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The count of *all* `ProjectManagerLabel` you could get from the connection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectProjectManagerLabelsByProjectManagerProjectIdAndProjectManagerLabelIdManyToManyEdge",
+          "description": "A `ProjectManagerLabel` edge in the connection, with data from `ProjectManager`.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Cursor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The `ProjectManagerLabel` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagersByProjectManagerLabelId",
+              "description": "Reads and enables pagination through a set of `ProjectManager`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManager`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagersOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectManagersConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -88872,6 +97407,83 @@
                 "kind": "OBJECT",
                 "name": "FormChange",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerFormChangesByLabel",
+              "description": "Computed column returns a composite value for each record in project_manager_label and the last related form_change if it exists",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ManagerFormChangesByLabelCompositeReturnFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ManagerFormChangesByLabelCompositeReturnsConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -98141,6 +106753,117 @@
               "deprecationReason": null
             },
             {
+              "name": "allProjectManagerLabels",
+              "description": "Reads and enables pagination through a set of `ProjectManagerLabel`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": "A condition to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelCondition",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": "A filter to be used in determining which values should be returned by the collection.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectManagerLabelFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeArchived",
+                  "description": "Indicates whether archived items should be included in the results or not.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IncludeArchivedOption",
+                    "ofType": null
+                  },
+                  "defaultValue": "NO"
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabelsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "allProjectManagers",
               "description": "Reads and enables pagination through a set of `ProjectManager`.",
               "args": [
@@ -99338,6 +108061,60 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ProjectManager",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabel",
+              "description": "Reads a single `ProjectManagerLabel` using its globally unique `ID`.",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "The globally unique `ID` to be used in selecting a single `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelByRowId",
+              "description": null,
+              "args": [
+                {
+                  "name": "rowId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -102163,6 +110940,218 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateProjectManagerLabelByRowIdInput",
+          "description": "All input for the `updateProjectManagerLabelByRowId` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelPatch",
+              "description": "An object where the defined keys will be set on the `ProjectManagerLabel` being updated.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectManagerLabelPatch",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rowId",
+              "description": "Unique ID for the project_manager_label record",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateProjectManagerLabelInput",
+          "description": "All input for the `updateProjectManagerLabel` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": "The globally unique `ID` which will identify a single `ProjectManagerLabel` to be updated.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelPatch",
+              "description": "An object where the defined keys will be set on the `ProjectManagerLabel` being updated.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectManagerLabelPatch",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateProjectManagerLabelPayload",
+          "description": "The output of our update `ProjectManagerLabel` mutation.",
+          "fields": [
+            {
+              "name": "cifUserByArchivedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByCreatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cifUserByUpdatedBy",
+              "description": "Reads a single `CifUser` that is related to this `ProjectManagerLabel`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CifUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "The exact same `clientMutationId` that was provided in the mutation input,\nunchanged and unused. May be used by a client to track mutations.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabel",
+              "description": "The `ProjectManagerLabel` that was updated by this mutation.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelEdge",
+              "description": "An edge for our `ProjectManagerLabel`. May be used by Relay 1.",
+              "args": [
+                {
+                  "name": "orderBy",
+                  "description": "The method to use when ordering `ProjectManagerLabel`.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ProjectManagerLabelsOrderBy",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[PRIMARY_KEY_ASC]"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabelsEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "query",
+              "description": "Our root query field type. Allows us to run any query from our mutation payload.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Query",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "UpdateProjectManagerPayload",
           "description": "The output of our update `ProjectManager` mutation.",
@@ -102277,6 +111266,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ProjectManagersEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectManagerLabelByProjectManagerLabelId",
+              "description": "Reads a single `ProjectManagerLabel` that is related to this `ProjectManager`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/app/schema/schema.json
+++ b/app/schema/schema.json
@@ -66283,6 +66283,41 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "DeleteProjectManagerLabelByLabelInput",
+          "description": "All input for the `deleteProjectManagerLabelByLabel` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "The label that project managers can be assigned to a project as",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "DeleteProjectManagerLabelByRowIdInput",
           "description": "All input for the `deleteProjectManagerLabelByRowId` mutation.",
           "fields": null,
@@ -79087,12 +79122,12 @@
           "description": "The type of change operation, defining the action taken when the form_change is committed.",
           "fields": [
             {
-              "name": "formChangeId",
+              "name": "formChange",
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Int",
+                "kind": "OBJECT",
+                "name": "FormChange",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -79105,18 +79140,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "newFormData",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "JSON",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -79153,31 +79176,11 @@
               "defaultValue": null
             },
             {
-              "name": "formChangeId",
-              "description": "Filter by the object’s `formChangeId` field.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "IntFilter",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
               "name": "label",
               "description": "Filter by the object’s `label` field.",
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "StringFilter",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "newFormData",
-              "description": "Filter by the object’s `newFormData` field.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "JSONFilter",
                 "ofType": null
               },
               "defaultValue": null
@@ -80261,6 +80264,33 @@
               "deprecationReason": null
             },
             {
+              "name": "deleteProjectManagerLabelByLabel",
+              "description": "Deletes a single `ProjectManagerLabel` using a unique key.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeleteProjectManagerLabelByLabelInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DeleteProjectManagerLabelPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "deleteProjectManagerLabelByRowId",
               "description": "Deletes a single `ProjectManagerLabel` using a unique key.",
               "args": [
@@ -80894,6 +80924,33 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "UpdateProjectManagerLabelInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateProjectManagerLabelPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateProjectManagerLabelByLabel",
+              "description": "Updates a single `ProjectManagerLabel` using a unique key and a patch.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateProjectManagerLabelByLabelInput",
                       "ofType": null
                     }
                   },
@@ -108094,6 +108151,33 @@
               "deprecationReason": null
             },
             {
+              "name": "projectManagerLabelByLabel",
+              "description": null,
+              "args": [
+                {
+                  "name": "label",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "projectManagerLabelByRowId",
               "description": null,
               "args": [
@@ -110929,6 +111013,55 @@
                 "ofType": {
                   "kind": "INPUT_OBJECT",
                   "name": "ProjectManagerPatch",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateProjectManagerLabelByLabelInput",
+          "description": "All input for the `updateProjectManagerLabelByLabel` mutation.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "label",
+              "description": "The label that project managers can be assigned to a project as",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectManagerLabelPatch",
+              "description": "An object where the defined keys will be set on the `ProjectManagerLabel` being updated.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectManagerLabelPatch",
                   "ofType": null
                 }
               },

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -11,10 +11,11 @@ $computed_column$
 
   with project_form_change_history as (
     select *
-      from cif.form_change
+      from cif.form_change fc
       where project_revision_id = $1.id
         and form_data_schema_name='cif'
         and form_data_table_name='project_manager'
+        and fc.created_by = (select id from cif.cif_user where uuid = (select sub from cif.session()))
     union
     select fc.*
       from cif.form_change fc
@@ -26,6 +27,7 @@ $computed_column$
         and change_status = 'committed'
         and form_data_record_id is not null
         and fc.updated_at = (select max(updated_at) from cif.form_change where form_data_record_id = pm.id)
+        and fc.created_by = (select id from cif.cif_user where uuid = (select sub from cif.session()))
   )
   select label, project_form_change_history.id as form_change_id, new_form_data
     from project_form_change_history

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -22,12 +22,7 @@ $computed_column$
       join cif.project_manager pm on
         fc.form_data_record_id = pm.id
         and pm.project_id = $1.project_id
-        and form_data_schema_name='cif'
-        and form_data_table_name='project_manager'
-        and change_status = 'committed'
-        and form_data_record_id is not null
-        and fc.updated_at = (select max(updated_at) from cif.form_change where form_data_record_id = pm.id)
-        and fc.created_by = (select id from cif.cif_user where uuid = (select sub from cif.session()))
+        and (fc.updated_at, fc.id) = (select max(updated_at), max(id) from cif.form_change where form_data_record_id = pm.id)
   )
   select label, row(project_form_change_history.*) as form_change
     from project_form_change_history

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -10,12 +10,13 @@ as
 $computed_column$
 
   with project_form_change_history as (
-    select *
+    select fc.*
       from cif.form_change fc
+      join cif.project_manager_label pml on cast(new_form_data->>'projectManagerLabelId' as integer) = pml.id
+        and (fc.updated_at, fc.id) = (select max(updated_at), max(id) from cif.form_change where cast(new_form_data->>'projectManagerLabelId' as integer) = pml.id)
       where project_revision_id = $1.id
         and form_data_schema_name='cif'
         and form_data_table_name='project_manager'
-        and fc.created_by = (select id from cif.cif_user where uuid = (select sub from cif.session()))
     union
     select fc.*
       from cif.form_change fc

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -1,0 +1,41 @@
+-- Deploy cif:computed_columns/project_revision_project_manager_form_changes_by_label to pg
+-- requires: tables/form_change
+-- requires: tables/project_manager
+
+begin;
+
+create or replace function cif.project_revision_project_manager_form_changes_by_label(cif.project_revision)
+returns setof cif.manager_form_changes_by_label_composite_return
+as
+$computed_column$
+
+  with project_form_change_history as (
+    select *
+      from cif.form_change
+      where project_revision_id = 3
+        and form_data_schema_name='cif'
+        and form_data_table_name='project_manager'
+    union
+    select fc.*
+      from cif.form_change fc
+      join cif.project_manager pm on
+        fc.form_data_record_id = pm.id
+        and pm.project_id = 1
+        and form_data_schema_name='cif'
+        and form_data_table_name='project_manager'
+        and change_status = 'committed'
+        and form_data_record_id is not null
+        and fc.updated_at = (select max(updated_at) from cif.form_change where form_data_record_id = pm.id)
+  )
+  select label, project_form_change_history.id as form_change_id, new_form_data
+    from project_form_change_history
+    right join cif.project_manager_label pml
+      on cast(new_form_data->>'projectManagerLabelId' as integer) = pml.id;
+
+$computed_column$ language sql stable;
+
+grant execute on function cif.project_revision_project_manager_form_changes_by_label to cif_internal, cif_external, cif_admin;
+
+comment on function cif.project_revision_project_manager_form_changes_by_label is 'Computed column returns a composite value for each record in project_manager_label and the last related form_change if it exists';
+
+commit;

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -12,7 +12,7 @@ $computed_column$
   with project_form_change_history as (
     select *
       from cif.form_change
-      where project_revision_id = 3
+      where project_revision_id = $1.id
         and form_data_schema_name='cif'
         and form_data_table_name='project_manager'
     union
@@ -20,7 +20,7 @@ $computed_column$
       from cif.form_change fc
       join cif.project_manager pm on
         fc.form_data_record_id = pm.id
-        and pm.project_id = 1
+        and pm.project_id = $1.project_id
         and form_data_schema_name='cif'
         and form_data_table_name='project_manager'
         and change_status = 'committed'

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -29,7 +29,7 @@ $computed_column$
         and fc.updated_at = (select max(updated_at) from cif.form_change where form_data_record_id = pm.id)
         and fc.created_by = (select id from cif.cif_user where uuid = (select sub from cif.session()))
   )
-  select label, project_form_change_history.id as form_change_id, new_form_data
+  select label, row(project_form_change_history.*) as form_change
     from project_form_change_history
     right join cif.project_manager_label pml
       on cast(new_form_data->>'projectManagerLabelId' as integer) = pml.id;

--- a/schema/deploy/tables/project_manager.sql
+++ b/schema/deploy/tables/project_manager.sql
@@ -5,7 +5,8 @@ begin;
 create table cif.project_manager (
   id integer primary key generated always as identity,
   project_id integer not null references cif.project(id),
-  cif_user_id integer not null references cif.cif_user(id)
+  cif_user_id integer not null references cif.cif_user(id),
+  project_manager_label_id integer not null references cif.project_manager_label(id)
 );
 
 select cif_private.upsert_timestamp_columns('cif', 'project_manager');
@@ -34,6 +35,7 @@ comment on table cif.project_manager is 'Join table to track assignment of cif u
 comment on column cif.project_manager.id is 'Unique ID for the project manager record';
 comment on column cif.project_manager.project_id is 'Foreign key to the project';
 comment on column cif.project_manager.cif_user_id is 'Foreign key to the cif user';
+comment on column cif.project_manager.project_manager_label_id is 'Foreign key to the project_manager_label table. Defines the list of labels that cif_users can be assigned to as a manager of a project';
 
 
 commit;

--- a/schema/deploy/tables/project_manager_label.sql
+++ b/schema/deploy/tables/project_manager_label.sql
@@ -42,4 +42,3 @@ values
   ('Ops Team Secondary');
 
 commit;
-

--- a/schema/deploy/tables/project_manager_label.sql
+++ b/schema/deploy/tables/project_manager_label.sql
@@ -5,10 +5,8 @@ begin;
 
 create table cif.project_manager_label (
   id integer primary key generated always as identity,
-  label varchar(1000) not null
+  label varchar(1000) not null unique
 );
-
-create unique index cif_project_manager_label_uindex on cif.project_manager_label (label);
 
 select cif_private.upsert_timestamp_columns('cif', 'project_manager_label');
 

--- a/schema/deploy/tables/project_manager_label.sql
+++ b/schema/deploy/tables/project_manager_label.sql
@@ -1,0 +1,45 @@
+-- Deploy cif:tables/project_manager_label to pg
+-- requires: schemas/main
+
+begin;
+
+create table cif.project_manager_label (
+  id integer primary key generated always as identity,
+  label varchar(1000) not null
+);
+
+create unique index cif_project_manager_label_uindex on cif.project_manager_label (label);
+
+select cif_private.upsert_timestamp_columns('cif', 'project_manager_label');
+
+do
+$grant$
+begin
+
+-- Grant cif_internal permissions
+perform cif_private.grant_permissions('select', 'project_manager_label', 'cif_internal');
+
+-- Grant cif_admin permissions
+perform cif_private.grant_permissions('select', 'project_manager_label', 'cif_admin');
+perform cif_private.grant_permissions('insert', 'project_manager_label', 'cif_admin');
+perform cif_private.grant_permissions('update', 'project_manager_label', 'cif_admin');
+
+-- Grant cif_external no permissions
+-- Grant cif_guest no permissions
+
+end
+$grant$;
+
+comment on table cif.project_manager_label is 'Lookup table for project manager labels. Records define the labels that project managers can be assigned to a project as';
+comment on column cif.project_manager_label.id is 'Unique ID for the project_manager_label record';
+comment on column cif.project_manager_label.label is 'The label that project managers can be assigned to a project as';
+
+insert into cif.project_manager_label (label)
+values
+  ('Tech Team Primary'),
+  ('Tech Team Secondary'),
+  ('Ops Team Primary'),
+  ('Ops Team Secondary');
+
+commit;
+

--- a/schema/deploy/types/manager_form_changes_by_label_composite_return.sql
+++ b/schema/deploy/types/manager_form_changes_by_label_composite_return.sql
@@ -1,0 +1,14 @@
+-- Deploy cif:types/manager_form_changes_by_label_composite_return to pg
+-- requires: schemas/main
+
+begin;
+
+create type cif.manager_form_changes_by_label_composite_return as (
+  label text,
+  form_change_id integer,
+  new_form_data jsonb
+);
+
+comment on type cif.manager_form_changes_by_label_composite_return is 'The type of change operation, defining the action taken when the form_change is committed.';
+
+commit;

--- a/schema/deploy/types/manager_form_changes_by_label_composite_return.sql
+++ b/schema/deploy/types/manager_form_changes_by_label_composite_return.sql
@@ -5,8 +5,7 @@ begin;
 
 create type cif.manager_form_changes_by_label_composite_return as (
   label text,
-  form_change_id integer,
-  new_form_data jsonb
+  form_change cif.form_change
 );
 
 comment on type cif.manager_form_changes_by_label_composite_return is 'The type of change operation, defining the action taken when the form_change is committed.';

--- a/schema/revert/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/revert/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -1,0 +1,7 @@
+-- Revert cif:computed_columns/project_revision_project_manager_form_changes_by_label from pg
+
+begin;
+
+drop function cif.project_revision_project_manager_form_changes_by_label;
+
+commit;

--- a/schema/revert/tables/project_manager_label.sql
+++ b/schema/revert/tables/project_manager_label.sql
@@ -1,0 +1,7 @@
+-- Revert cif:tables/project_manager_label from pg
+
+begin;
+
+drop table cif.project_manager_label;
+
+commit;

--- a/schema/revert/types/manager_form_changes_by_label_composite_return.sql
+++ b/schema/revert/types/manager_form_changes_by_label_composite_return.sql
@@ -1,0 +1,7 @@
+-- Revert cif:types/manager_form_changes_by_label_composite_return from pg
+
+begin;
+
+drop type cif.manager_form_changes_by_label_composite_return;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -45,7 +45,6 @@ tables/contact 2022-01-19T22:40:59Z Matthieu Foucault <matthieu@button.is> # add
 tables/project_contact 2022-01-21T20:45:52Z Matthieu Foucault <matthieu@button.is> # add an association table for projects and contacts
 computed_columns/contact_full_name 2022-01-21T21:33:00Z Matthieu Foucault <matthieu@button.is> # add a computed column for a contact's full name
 computed_columns/contact_full_phone 2022-01-21T21:33:18Z Matthieu Foucault <matthieu@button.is> # add a computed column for a contact's full phone number
-mutations/create_project [tables/project] 2021-11-09T21:34:55Z Dylan Leard <dylan@button.is> # Custom mutation to create a project
 computed_columns/project_revision_project_form_change [tables/project_revision] 2021-12-09T18:55:14Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project record, within a project revision
 functions/pending_new_project_revision 2021-12-22T23:40:21Z Matthieu Foucault <matthieu@button.is> # add function returning a pending new project revision created by the current user
 mutations/create_form_change 2022-02-01T00:52:42Z Matthieu Foucault <matthieu@button.is> # add custom mutation to create a form change
@@ -53,9 +52,9 @@ functions/pending_new_contact_form_change 2022-02-02T15:57:04Z Matthieu Foucault
 computed_columns/contact_pending_form_change 2022-02-07T18:30:37Z Matthieu Foucault <matthieu@button.is> # add a computed column returning the pending form_change for a given contact
 mutations/add_contact_to_revision 2022-01-27T23:48:16Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Custom mutation that prepopulates an insert to the form change table for a new contact on a a project revision
 util_functions/import_swrs_operators [tables/operator schemas/private] 2022-02-09T17:17:00Z Dylan Leard <dylan@button.is> # Add function to import operators from swrs using a foreign data wrapper
-tables/project_manager 2021-11-30T22:00:42Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track project manager assignments to projects
 tables/project_manager_label [schemas/main] 2022-02-17T23:44:42Z Dylan Leard <dylan@button.is> # Table contains the possible labels that a cif_user can be assigned to as a manager of a project
-types/manager_form_changes_by_label_composite_return [schemas/main] 2022-02-18T20:58:37Z Dylan Leard <dylan@button.is> # Add custom composite return type for computed column project_revision_project_manager_form_changes_by_label
+tables/project_manager 2021-11-30T22:00:42Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track project manager assignments to projects
+mutations/create_project [tables/project] 2021-11-09T21:34:55Z Dylan Leard <dylan@button.is> # Custom mutation to create a project
 computed_columns/project_revision_project_manager_form_change [tables/project_revision] 2021-12-09T19:32:45Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project manager association, within a project revision
 types/manager_form_changes_by_label_composite_return [schemas/main] 2022-02-18T20:58:37Z Dylan Leard <dylan@button.is> # Add custom composite return type for computed column project_revision_project_manager_form_changes_by_label
 computed_columns/project_revision_project_manager_form_changes_by_label [tables/project_revision tables/project_manager] 2022-02-18T21:32:45Z Dylan Leard <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the set of form changes related to the project manager association by project_manager_label, within a project revision

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -55,4 +55,6 @@ mutations/add_contact_to_revision 2022-01-27T23:48:16Z Pierre Bastianelli <pierr
 util_functions/import_swrs_operators [tables/operator schemas/private] 2022-02-09T17:17:00Z Dylan Leard <dylan@button.is> # Add function to import operators from swrs using a foreign data wrapper
 tables/project_manager 2021-11-30T22:00:42Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track project manager assignments to projects
 tables/project_manager_label [schemas/main] 2022-02-17T23:44:42Z Dylan Leard <dylan@button.is> # Table contains the possible labels that a cif_user can be assigned to as a manager of a project
+types/manager_form_changes_by_label_composite_return [schemas/main] 2022-02-18T20:58:37Z Dylan Leard <dylan@button.is> # Add custom composite return type for computed column project_revision_project_manager_form_changes_by_label
 computed_columns/project_revision_project_manager_form_change [tables/project_revision] 2021-12-09T19:32:45Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project manager association, within a project revision
+

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -41,18 +41,18 @@ trigger_functions/commit_project_revision 2021-12-07T00:37:33Z Pierre Bastianell
 tables/project_revision 2021-12-07T00:39:51Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track global project revisions - containing multiple changes
 tables/form_change [tables/change_status] 2021-11-04T20:58:49Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Form history table to track changes to records
 tables/attachment 2021-11-24T21:24:45Z Alex Zorkin <alex@bigthink.io> # Add schema for attachments
-tables/project_manager 2021-11-30T22:00:42Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track project manager assignments to projects
 tables/contact 2022-01-19T22:40:59Z Matthieu Foucault <matthieu@button.is> # add contact table
 tables/project_contact 2022-01-21T20:45:52Z Matthieu Foucault <matthieu@button.is> # add an association table for projects and contacts
 computed_columns/contact_full_name 2022-01-21T21:33:00Z Matthieu Foucault <matthieu@button.is> # add a computed column for a contact's full name
 computed_columns/contact_full_phone 2022-01-21T21:33:18Z Matthieu Foucault <matthieu@button.is> # add a computed column for a contact's full phone number
 mutations/create_project [tables/project] 2021-11-09T21:34:55Z Dylan Leard <dylan@button.is> # Custom mutation to create a project
 computed_columns/project_revision_project_form_change [tables/project_revision] 2021-12-09T18:55:14Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project record, within a project revision
-computed_columns/project_revision_project_manager_form_change [tables/project_revision] 2021-12-09T19:32:45Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project manager association, within a project revision
 functions/pending_new_project_revision 2021-12-22T23:40:21Z Matthieu Foucault <matthieu@button.is> # add function returning a pending new project revision created by the current user
 mutations/create_form_change 2022-02-01T00:52:42Z Matthieu Foucault <matthieu@button.is> # add custom mutation to create a form change
 functions/pending_new_contact_form_change 2022-02-02T15:57:04Z Matthieu Foucault <matthieu@button.is> # add function allowing the current user to retrieve a draft contact
 computed_columns/contact_pending_form_change 2022-02-07T18:30:37Z Matthieu Foucault <matthieu@button.is> # add a computed column returning the pending form_change for a given contact
 mutations/add_contact_to_revision 2022-01-27T23:48:16Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Custom mutation that prepopulates an insert to the form change table for a new contact on a a project revision
 util_functions/import_swrs_operators [tables/operator schemas/private] 2022-02-09T17:17:00Z Dylan Leard <dylan@button.is> # Add function to import operators from swrs using a foreign data wrapper
+tables/project_manager 2021-11-30T22:00:42Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A table to track project manager assignments to projects
 tables/project_manager_label [schemas/main] 2022-02-17T23:44:42Z Dylan Leard <dylan@button.is> # Table contains the possible labels that a cif_user can be assigned to as a manager of a project
+computed_columns/project_revision_project_manager_form_change [tables/project_revision] 2021-12-09T19:32:45Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project manager association, within a project revision

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -57,4 +57,5 @@ tables/project_manager 2021-11-30T22:00:42Z Pierre Bastianelli <pierre.bastianel
 tables/project_manager_label [schemas/main] 2022-02-17T23:44:42Z Dylan Leard <dylan@button.is> # Table contains the possible labels that a cif_user can be assigned to as a manager of a project
 types/manager_form_changes_by_label_composite_return [schemas/main] 2022-02-18T20:58:37Z Dylan Leard <dylan@button.is> # Add custom composite return type for computed column project_revision_project_manager_form_changes_by_label
 computed_columns/project_revision_project_manager_form_change [tables/project_revision] 2021-12-09T19:32:45Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the form change related to the project manager association, within a project revision
-
+types/manager_form_changes_by_label_composite_return [schemas/main] 2022-02-18T20:58:37Z Dylan Leard <dylan@button.is> # Add custom composite return type for computed column project_revision_project_manager_form_changes_by_label
+computed_columns/project_revision_project_manager_form_changes_by_label [tables/project_revision tables/project_manager] 2022-02-18T21:32:45Z Dylan Leard <pierre.bastianelli@gov.bc.ca> # Computed column to retrieve the set of form changes related to the project manager association by project_manager_label, within a project revision

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -55,3 +55,4 @@ functions/pending_new_contact_form_change 2022-02-02T15:57:04Z Matthieu Foucault
 computed_columns/contact_pending_form_change 2022-02-07T18:30:37Z Matthieu Foucault <matthieu@button.is> # add a computed column returning the pending form_change for a given contact
 mutations/add_contact_to_revision 2022-01-27T23:48:16Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Custom mutation that prepopulates an insert to the form change table for a new contact on a a project revision
 util_functions/import_swrs_operators [tables/operator schemas/private] 2022-02-09T17:17:00Z Dylan Leard <dylan@button.is> # Add function to import operators from swrs using a foreign data wrapper
+tables/project_manager_label [schemas/main] 2022-02-17T23:44:42Z Dylan Leard <dylan@button.is> # Table contains the possible labels that a cif_user can be assigned to as a manager of a project

--- a/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
+++ b/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
@@ -1,0 +1,207 @@
+begin;
+
+select * from no_plan();
+
+-- Setting up the test data for the following scenario:
+-- For our project (id = 1), we have multiple revisions:
+-- revision 3: committed, with a form change for the project table (id = 4)
+-- revision 4: committed, without a form change for the project table
+-- revision 5: pending, without a form change for the project table
+-- alter table cif.form_change disable trigger commit_form_change;
+
+/** Basic Setup: Entities needed by dependency **/
+
+truncate table cif.cif_user restart identity cascade;
+truncate table cif.project restart identity cascade;
+truncate table cif.funding_stream_rfp restart identity cascade;
+
+insert into cif.cif_user (uuid, first_name, last_name, email_address)
+values
+  ('00000000-0000-0000-0000-000000000000', 'user 1', 'Testuser', 'cif_internal@somemail.com'),
+  ('00000000-0000-0000-0000-000000000001', 'user 2', 'Testuser', 'cif_external@somemail.com'),
+  ('00000000-0000-0000-0000-000000000002', 'user 3', 'Testuser', 'cif_admin@somemail.com'),
+  ('00000000-0000-0000-0000-000000000003', 'user 4', 'Testuser', 'cif@somemail.com');
+
+insert into cif.operator(id, legal_name)
+  overriding system value
+  values (1, 'test operator');
+
+insert into cif.funding_stream (name, description) values ('EP', 'Emissions Performance'), ('IA', 'Innovation Accelerator');
+
+insert into cif.funding_stream_rfp (year, funding_stream_id) values
+(2022, 1);
+
+insert into cif.change_status (status, triggers_commit, active)
+values
+  ('pending', false, true),
+  ('committed', true, true);
+
+  insert into cif.project_manager_label (label)
+values
+  ('1 Label'),
+  ('2 Label'),
+  ('3 Label'),
+  ('4 Label');
+
+insert into cif.project_status (name, description) values
+('Test Status', 'Test Status');
+
+insert into cif.project(id, operator_id, funding_stream_rfp_id, project_status_id, rfp_number, summary, project_name)
+  overriding system value
+  values
+    (1, 1, 1, 1, '001', 'summary', 'project 1'),
+    (2, 1, 1, 1, '002', 'summary', 'project 2');
+
+insert into cif.project_revision(id, change_status, project_id)
+  overriding system value
+  values (1, 'pending', 1), (2, 'pending', 1), (3, 'pending', 1), (4, 'pending', 2), (5, 'pending', 2);
+
+/** Basic Setup End **/
+
+/**
+  Create form_change records for testing.
+  There are 9 form_change records in total.
+  7 form_change records are for project with id = 1
+  There are 3 revisions within these 7 form_change records.
+  The flow is:
+    Revision 1 (committed):
+      create 3 records
+    Revision 2 (committed):
+      delete 1 record created in revision 1
+      update 1 record created in revision 1
+    Revision 3 (pending) - This pending revision is the main focus of the tests:
+      create 1 record
+      delete 1 record created in revision 1
+  There are 2 revisions for project with id = 2
+    These are here to make sure that the function does not return any form_change records for projects outside the scope of the project_revision passed as a parameter.
+    Revision 4 is committed
+    Revision 5 is pending
+**/
+
+insert into cif.form_change(
+  id, operation, form_data_schema_name, form_data_table_name, form_data_record_id, project_revision_id, change_reason, json_schema_name, new_form_data)
+  overriding system value
+  values
+    (1, 'create', 'cif', 'project_manager', null, 1, 'test reason', 'project', '{"projectId": 1, "cifUserId": 1, "projectManagerLabelId": 1}'),
+    (2, 'create', 'cif', 'project_manager', null, 1, 'test reason', 'project', '{"projectId": 1, "cifUserId": 2, "projectManagerLabelId": 2}'),
+    (3, 'create', 'cif', 'project_manager', null, 1, 'test reason', 'project', '{"projectId": 1, "cifUserId": 3, "projectManagerLabelId": 3}'),
+    (4, 'archive', 'cif', 'project_manager', 1, 2, 'test reason', 'project',null),
+    (5, 'update', 'cif', 'project_manager', 2, 2, 'test reason', 'project', '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 2}'),
+    (6, 'create', 'cif', 'project_manager', null, 3, 'test reason', 'project', '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 4}'),
+    (7, 'archive', 'cif', 'project_manager', 3, 3, 'test reason', 'project', null),
+    (8, 'create', 'cif', 'project_manager', null, 4, 'test reason', 'project', '{"projectId": 2, "cifUserId": 4, "projectManagerLabelId": 1}'),
+    (9, 'create', 'cif', 'project_manager', null, 5, 'test reason', 'project', '{"projectId": 2, "cifUserId": 3, "projectManagerLabelId": 3}');
+
+-- Commit Revisions 1, 2 and 4.
+update cif.project_revision set change_status = 'committed' where id in (1,2,4);
+
+alter table cif.form_change disable trigger _100_committed_changes_are_immutable;
+alter table cif.form_change disable trigger _100_timestamps;
+
+-- Ensure the updated_at timestamps make sense (Not all are updated at the same time, group and stagger the updates by revision)
+update cif.form_change set updated_at = updated_at + interval '1 hour' where id in (1,2,3);
+update cif.form_change set updated_at = updated_at + interval '2 hours' where id in (4,5);
+update cif.form_change set updated_at = updated_at + interval '3 hours' where id in (6,7);
+update cif.form_change set updated_at = updated_at + interval '5 hours' where id in (8,9);
+
+
+  select'MATTHIEU-------------------------------------------';
+
+
+  with project_form_change_history as (
+    select *
+      from cif.form_change
+      where project_revision_id = 3
+        and form_data_schema_name='cif'
+        and form_data_table_name='project_manager'
+    union
+    select fc.*
+      from cif.form_change fc
+      join cif.project_manager pm on
+        fc.form_data_record_id = pm.id
+        and pm.project_id = 1
+        and form_data_schema_name='cif'
+        and form_data_table_name='project_manager'
+        and change_status = 'committed'
+        and form_data_record_id is not null
+        and fc.updated_at = (select max(updated_at) from cif.form_change where form_data_record_id = pm.id)
+  )
+  select label, project_form_change_history.id as id, operation, form_data_record_id, new_form_data from project_form_change_history
+  right join cif.project_manager_label pml
+  on cast(new_form_data->>'projectManagerLabelId' as integer) = pml.id;
+
+
+select is(
+  (
+    with record as (
+      select row(project_revision.*)::cif.project_revision
+      from cif.project_revision where id=3
+    ) select count(*) from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+  ),
+  (select count(*) from cif.project_manager_label),
+  'Returns the same number of records as there are project_manager_label records'
+);
+
+select is(
+  (
+    with record as (
+      select row(project_revision.*)::cif.project_revision
+      from cif.project_revision where id=3
+    ) select new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+      where label='1 Label'
+  ),
+  NULL,
+  'The new_form_data returned is NULL for the record with label "1 Label". It was archived in revision 2'
+);
+
+select is(
+  (
+    with record as (
+      select row(project_revision.*)::cif.project_revision
+      from cif.project_revision where id=3
+    ) select new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+      where label='2 Label'
+  ),
+  '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 2}'::jsonb,
+  'The new_form_data returned for the record with label "2 Label" matches the data that was updated in revision 2.'
+);
+
+select is(
+  (
+    with record as (
+      select row(project_revision.*)::cif.project_revision
+      from cif.project_revision where id=3
+    ) select new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+      where label='3 Label'
+  ),
+  NULL,
+  'The new_form_data returned is NULL for the record with label "3 Label". It was archived in revision 3'
+);
+
+select is(
+  (
+    with record as (
+      select row(project_revision.*)::cif.project_revision
+      from cif.project_revision where id=3
+    ) select new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+      where label='4 Label'
+  ),
+  '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 4}'::jsonb,
+  'The new_form_data returned for the record with label "4 Label" matches the data that was created in revision 3.'
+);
+
+select is(
+  (
+    with record as (
+      select row(project_revision.*)::cif.project_revision
+      from cif.project_revision where id=3
+    ) select count(*) from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+      where cast(new_form_data->>'projectId' as integer) = 2
+  ),
+  0::bigint,
+  'Only returns data for the project matching the project_revision''s project_id. (Does not return data from other projects)'
+);
+
+select finish();
+
+rollback;

--- a/schema/test/unit/functions/pending_new_project_revision_test.sql
+++ b/schema/test/unit/functions/pending_new_project_revision_test.sql
@@ -48,7 +48,8 @@ update cif.form_change set new_form_data=format('{
 
 update cif.form_change set new_form_data=format('{
       "projectId": %s,
-      "cifUserId": %s
+      "cifUserId": %s,
+      "projectManagerLabelId": 1
     }',
     (select form_data_record_id from cif.form_change
         where form_data_table_name='project'

--- a/schema/test/unit/tables/project_manager_label_test.sql
+++ b/schema/test/unit/tables/project_manager_label_test.sql
@@ -1,0 +1,117 @@
+begin;
+select plan(13);
+
+select has_table('cif', 'project_manager_label', 'table cif.project_manager_label exists');
+
+select columns_are(
+  'cif',
+  'project_manager_label',
+  ARRAY[
+    'id',
+    'label',
+    'created_at',
+    'created_by',
+    'updated_at',
+    'updated_by',
+    'archived_at',
+    'archived_by'
+  ],
+  'columns in cif.project_manager_label match expected columns'
+);
+
+select index_is_unique( 'cif', 'project_manager_label', 'cif_project_manager_label_uindex', 'There is a unique index on the label column' );
+
+-- Row level security tests --
+
+-- Test setup
+set jwt.claims.sub to '11111111-1111-1111-1111-111111111111';
+
+-- cif_admin
+set role cif_admin;
+select concat('current user is: ', (select current_user));
+
+select lives_ok(
+  $$
+    select * from cif.project_manager_label
+  $$,
+    'cif_admin can view all data in project_manager_label table'
+);
+
+select lives_ok(
+  $$
+    insert into cif.project_manager_label (label) values ('admin new label');
+  $$,
+    'cif_admin can insert data in project_manager_label table'
+);
+
+select results_eq(
+  $$
+    select count(id) from cif.project_manager_label where label = 'admin new label'
+  $$,
+    ARRAY[1::bigint],
+    'Data was inserted by cif_admin'
+);
+
+
+select lives_ok(
+  $$
+    update cif.project_manager_label set label = 'changed by admin' where label='admin new label';
+  $$,
+    'cif_admin can change data in project_manager_label table'
+);
+
+select results_eq(
+  $$
+    select count(id) from cif.project_manager_label where label = 'changed by admin'
+  $$,
+    ARRAY[1::bigint],
+    'Data was changed by cif_admin'
+);
+
+select throws_like(
+  $$
+    delete from cif.project_manager_label where id=1
+  $$,
+  'permission denied%',
+    'Administrator cannot delete rows from table project_manager_label'
+);
+
+
+-- cif_internal
+set role cif_internal;
+select concat('current user is: ', (select current_user));
+
+select results_eq(
+  $$
+    select count(*) from cif.project_manager_label
+  $$,
+  ARRAY['5'::bigint],
+    'cif_internal can view all data from project_manager_label'
+);
+
+select throws_like(
+  $$
+    insert into cif.project_manager_label (label) values ('created_by_internal')
+  $$,
+  'permission denied%',
+  'cif_internal cannot insert data in the project_manager_label table'
+);
+
+select throws_like(
+  $$
+    update cif.project_manager_label set label = 'changed_by_internal' where id=1
+  $$,
+  'permission denied%',
+  'cif_internal cannot update data in the project_manager_label table'
+);
+
+select throws_like(
+  $$
+    delete from cif.project_manager_label where id=1
+  $$,
+  'permission denied%',
+    'cif_internal cannot delete rows from table_project_manager_label'
+);
+
+select finish();
+rollback;

--- a/schema/test/unit/tables/project_manager_label_test.sql
+++ b/schema/test/unit/tables/project_manager_label_test.sql
@@ -19,7 +19,7 @@ select columns_are(
   'columns in cif.project_manager_label match expected columns'
 );
 
-select index_is_unique( 'cif', 'project_manager_label', 'cif_project_manager_label_uindex', 'There is a unique index on the label column' );
+select col_is_unique( 'cif', 'project_manager_label', 'label', 'There is a unique constraint on the label column' );
 
 -- Row level security tests --
 

--- a/schema/test/unit/trigger_functions/commit_project_revision_test.sql
+++ b/schema/test/unit/trigger_functions/commit_project_revision_test.sql
@@ -35,7 +35,8 @@ update cif.form_change set new_form_data=format('{
 
 update cif.form_change set new_form_data=format('{
       "projectId": %s,
-      "cifUserId": %s
+      "cifUserId": %s,
+      "projectManagerLabelId": 1
     }',
     (select form_data_record_id from cif.form_change
         where form_data_table_name='project'

--- a/schema/verify/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/verify/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -1,0 +1,7 @@
+-- Verify cif:computed_columns/project_revision_project_manager_form_changes_by_label on pg
+
+begin;
+
+select pg_get_functiondef('cif.project_revision_project_manager_form_changes_by_label(cif.project_revision)'::regprocedure);
+
+rollback;

--- a/schema/verify/tables/project_manager_label.sql
+++ b/schema/verify/tables/project_manager_label.sql
@@ -1,0 +1,16 @@
+-- Verify cif:tables/project_manager_label on pg
+
+begin;
+
+select pg_catalog.has_table_privilege('cif.project_manager_label', 'select');
+
+-- cif_internal Grants
+select cif_private.verify_grant('select', 'project_manager_label', 'cif_internal');
+
+-- cif_admin Grants
+select cif_private.verify_grant('select', 'project_manager_label', 'cif_admin');
+select cif_private.verify_grant('insert', 'project_manager_label', 'cif_admin');
+select cif_private.verify_grant('update', 'project_manager_label', 'cif_admin');
+
+
+rollback;

--- a/schema/verify/types/manager_form_changes_by_label_composite_return.sql
+++ b/schema/verify/types/manager_form_changes_by_label_composite_return.sql
@@ -1,0 +1,13 @@
+-- Verify cif:types/manager_form_changes_by_label_composite_return on pg
+
+begin;
+
+do $$
+  begin
+    assert (
+      select true from pg_catalog.pg_type where typname = 'manager_form_changes_by_label_composite_return'
+    ), 'type "manager_form_changes_by_label_composite_return" is not defined';
+  end;
+$$;
+
+rollback;


### PR DESCRIPTION
Adding multiple project managers will need to iterate over the # of records in the project_manager_label table and render a form whether there is form_data or not.

This computed column returns a composite return value that always contains one record for each project_manager_label and the form_data for that project and label if it exists.

Committed form_data is retrieved by latest updated (last committed).
Pending form_data takes precedence over committed form_data.
Pending form_data is only returned to the user who created it (allows concurrent editing).

This should be the majority of the database-related work required for #133