### PR TITLE
Chore: simplified managers computed column

### DIFF
--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -23287,28 +23287,11 @@ input KeycloakJwtFilter {
 }
 
 """
-The type of change operation, defining the action taken when the form_change is committed.
+A composite return type for the project_revision_project_manager_form_changes_by_label computed column. Returns a record for each active label and the last related form_change if it exists.
 """
 type ManagerFormChangesByLabelCompositeReturn {
   formChange: FormChange
-  label: String
-}
-
-"""
-A filter to be used against `ManagerFormChangesByLabelCompositeReturn` object types. All fields are combined with a logical ‘and.’
-"""
-input ManagerFormChangesByLabelCompositeReturnFilter {
-  """Checks for all expressions in this list."""
-  and: [ManagerFormChangesByLabelCompositeReturnFilter!]
-
-  """Filter by the object’s `label` field."""
-  label: StringFilter
-
-  """Negates the expression."""
-  not: ManagerFormChangesByLabelCompositeReturnFilter
-
-  """Checks for any expressions in this list."""
-  or: [ManagerFormChangesByLabelCompositeReturnFilter!]
+  projectManagerLabel: ProjectManagerLabel
 }
 
 """
@@ -28348,11 +28331,6 @@ type ProjectRevision implements Node {
 
     """Read all values in the set before (above) this cursor."""
     before: Cursor
-
-    """
-    A filter to be used in determining which values should be returned by the collection.
-    """
-    filter: ManagerFormChangesByLabelCompositeReturnFilter
 
     """Only read the first `n` values of the set."""
     first: Int

--- a/app/schema/schema.json
+++ b/app/schema/schema.json
@@ -79119,7 +79119,7 @@
         {
           "kind": "OBJECT",
           "name": "ManagerFormChangesByLabelCompositeReturn",
-          "description": "The type of change operation, defining the action taken when the form_change is committed.",
+          "description": "A composite return type for the project_revision_project_manager_form_changes_by_label computed column. Returns a record for each active label and the last related form_change if it exists.",
           "fields": [
             {
               "name": "formChange",
@@ -79134,12 +79134,12 @@
               "deprecationReason": null
             },
             {
-              "name": "label",
+              "name": "projectManagerLabel",
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "ProjectManagerLabel",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -79148,73 +79148,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "ManagerFormChangesByLabelCompositeReturnFilter",
-          "description": "A filter to be used against `ManagerFormChangesByLabelCompositeReturn` object types. All fields are combined with a logical ‘and.’",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "and",
-              "description": "Checks for all expressions in this list.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "ManagerFormChangesByLabelCompositeReturnFilter",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "label",
-              "description": "Filter by the object’s `label` field.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "StringFilter",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "not",
-              "description": "Negates the expression.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ManagerFormChangesByLabelCompositeReturnFilter",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "or",
-              "description": "Checks for any expressions in this list.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "ManagerFormChangesByLabelCompositeReturnFilter",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -97500,16 +97433,6 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Cursor",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "filter",
-                  "description": "A filter to be used in determining which values should be returned by the collection.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "ManagerFormChangesByLabelCompositeReturnFilter",
                     "ofType": null
                   },
                   "defaultValue": null

--- a/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
+++ b/schema/deploy/computed_columns/project_revision_project_manager_form_changes_by_label.sql
@@ -10,7 +10,7 @@ as
 $computed_column$
 
   with latest_changes as (
-    select distinct on (new_form_data->'projectManagerLabelId') * from cif.form_change
+    select * from cif.form_change
     where project_revision_id = $1.id
     order by new_form_data->'projectManagerLabelId', updated_at desc, id desc
   ) select row(pml.*), row(latest_changes.*) as form_change

--- a/schema/deploy/mutations/create_project.sql
+++ b/schema/deploy/mutations/create_project.sql
@@ -43,7 +43,7 @@ begin
     'Creating new project: project record',
     'project'
   ), (
-    format('{ "projectId": %s }', next_project_id)::jsonb,
+    format('{ "projectId": %s, "projectManagerLabelId": 1 }', next_project_id)::jsonb,
     'create',
     'cif',
     'project_manager',

--- a/schema/deploy/types/manager_form_changes_by_label_composite_return.sql
+++ b/schema/deploy/types/manager_form_changes_by_label_composite_return.sql
@@ -4,10 +4,10 @@
 begin;
 
 create type cif.manager_form_changes_by_label_composite_return as (
-  label text,
+  project_manager_label cif.project_manager_label,
   form_change cif.form_change
 );
 
-comment on type cif.manager_form_changes_by_label_composite_return is 'The type of change operation, defining the action taken when the form_change is committed.';
+comment on type cif.manager_form_changes_by_label_composite_return is 'A composite return type for the project_revision_project_manager_form_changes_by_label computed column. Returns a record for each active label and the last related form_change if it exists.';
 
 commit;

--- a/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
+++ b/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
@@ -184,10 +184,7 @@ select is(
       where (r).project_manager_label.label = '2 Label'
   ),
   '{"projectId": 1, "cifUserId": 1, "projectManagerLabelId": 2}'::jsonb,
-  $$
-    The new_form_data returned for the record with label "2 Label" matches the data that was updated in revision 3.
-    (Function returns latest committed form_change record, ordered by id if records have identical updated_at values)
-  $$
+    'The new_form_data returned for the record with label "2 Label" matches the data that was updated in revision 3.'
 );
 
 select is(
@@ -199,10 +196,7 @@ select is(
       where (r).project_manager_label.label = '3 Label'
   ),
   NULL,
-  $$
-    The new_form_data returned is NULL for the record with label "3 Label". It is currently being archived in revision 3
-    (Function returns the pending form_change record in favor of the latest committed record)
-  $$
+    'The new_form_data returned is NULL for the record with label "3 Label". It is currently being archived in revision 3'
 );
 
 select is(
@@ -229,7 +223,7 @@ select is(
       where ((r).form_change.new_form_data->'projectId')::int = 2
   ),
   0::bigint,
-  'Only returns data for the project matching the project_revision''s project_id. (Does not return data from other projects)'
+  'Function only returns data for the project matching the project_revision''s project_id. (Does not return data from other projects)'
 );
 
 select finish();

--- a/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
+++ b/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
@@ -1,7 +1,7 @@
 begin;
 SET client_min_messages TO WARNING; -- don't show all the truncate messages
 
-select plan(6);
+select plan(7);
 
 /** Basic Setup: Entities needed by dependency **/
 
@@ -56,64 +56,86 @@ insert into cif.project_revision(id, change_status, project_id)
 
 /**
   Create form_change records for testing.
-  There are 9 form_change records in total.
-  7 form_change records are for project with id = 1
-  There are 3 revisions within these 7 form_change records.
+  There are 12 form_change records in total.
+  10 form_change records are for project with id = 1
+  There are 3 revisions within these 10 form_change records.
   The flow is:
-    Revision 1 (committed):
+    Revision id=1 (committed):
       create 3 records
-    Revision 2 (committed):
+    Revision id=2 (committed):
       delete 1 record created in revision 1
       update 1 record created in revision 1
-    Revision 3 (pending) - This pending revision is the main focus of the tests:
+      (one update is an unchanged record from revision 1)
+    Revision id=3 (pending) - This pending revision is the main focus of the tests:
       create 1 record -> one user creates a record in form_change with id=6 another user creates a record for the same label in form_change with id=11 (concurrency check)
-      delete 1 record created in revision 1
-    Revision 2 (committed):
-      update 1 record (same record updated in revision 2) with the exact same updated_at value. This ensures that records with identical updated_at values are ordered by id desc.
+      delete 1 record
+      update 1 record (user 1)
+      update 1 record (user 2) - concurrency check
   There are 2 revisions for project with id = 2
     These are here to make sure that the function does not return any form_change records for projects outside the scope of the project_revision passed as a parameter.
-    Revision 4 is committed
-    Revision 5 is pending
+    Revision id=4 is committed
+    Revision id=5 is pending
 **/
 
 insert into cif.form_change(
   id, operation, form_data_schema_name, form_data_table_name, form_data_record_id, project_revision_id, change_reason, json_schema_name, new_form_data)
   overriding system value
   values
+    -- Create 3 records in revision 1 (committed) non-archived label ids: 1,2,3
     (1, 'create', 'cif', 'project_manager', null, 1, 'test reason', 'project', '{"projectId": 1, "cifUserId": 1, "projectManagerLabelId": 1}'),
     (2, 'create', 'cif', 'project_manager', null, 1, 'test reason', 'project', '{"projectId": 1, "cifUserId": 2, "projectManagerLabelId": 2}'),
     (3, 'create', 'cif', 'project_manager', null, 1, 'test reason', 'project', '{"projectId": 1, "cifUserId": 3, "projectManagerLabelId": 3}'),
+    -- Archive a record and update a record in revision 2 (committed) non-archived label ids:: 2,3
     (4, 'archive', 'cif', 'project_manager', 1, 2, 'test reason', 'project',null),
-    (5, 'update', 'cif', 'project_manager', 2, 2, 'test reason', 'project', '{"projectId": 1, "cifUserId": 3, "projectManagerLabelId": 2}'),
-    (6, 'create', 'cif', 'project_manager', null, 3, 'test reason', 'project', '{"projectId": 1, "cifUserId": 2, "projectManagerLabelId": 4}'),
-    (7, 'archive', 'cif', 'project_manager', 3, 3, 'test reason', 'project', null),
-    (8, 'create', 'cif', 'project_manager', null, 4, 'test reason', 'project', '{"projectId": 2, "cifUserId": 4, "projectManagerLabelId": 1}'),
-    (9, 'create', 'cif', 'project_manager', null, 5, 'test reason', 'project', '{"projectId": 2, "cifUserId": 3, "projectManagerLabelId": 3}'),
-    (10, 'update', 'cif', 'project_manager', 2, 6, 'test reason', 'project', '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 2}');
+    (5, 'update', 'cif', 'project_manager', 2, 2, 'test reason', 'project', '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 2}'),
+    (6, 'update', 'cif', 'project_manager', 3, 2, 'test reason', 'project', '{"projectId": 1, "cifUserId": 3, "projectManagerLabelId": 3}'),
+    -- Create a record, update a record and archive a record in revision 3 (pending) non-archived label ids: 2,4
+    (7, 'create', 'cif', 'project_manager', null, 3, 'test reason', 'project', '{"projectId": 1, "cifUserId": 2, "projectManagerLabelId": 4}'),
+    (8, 'archive', 'cif', 'project_manager', 3, 3, 'test reason', 'project', null),
+    (9, 'update', 'cif', 'project_manager', 2, 3, 'test reason', 'project', '{"projectId": 1, "cifUserId": 1, "projectManagerLabelId": 2}'),
+    -- Create a record in a different project (committed)
+    (10, 'create', 'cif', 'project_manager', null, 4, 'test reason', 'project', '{"projectId": 2, "cifUserId": 4, "projectManagerLabelId": 1}'),
+    -- Create a record in a different project (pending)
+    (11, 'update', 'cif', 'project_manager', null, 5, 'test reason', 'project', '{"projectId": 2, "cifUserId": 3, "projectManagerLabelId": 1}');
 
+-- update a record concurrently in the same pending revision (3) as a different user
 set jwt.claims.sub to '00000000-0000-0000-0000-000000000001';
 insert into cif.form_change(
   id, operation, form_data_schema_name, form_data_table_name, form_data_record_id, project_revision_id, change_reason, json_schema_name, new_form_data)
   overriding system value
   values
-(11, 'create', 'cif', 'project_manager', null, 3, 'test reason', 'project', '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 4}');
+    (12, 'create', 'cif', 'project_manager', null, 3, 'test reason', 'project', '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 4}');
 
--- Commit Revisions 1, 2 and 4.
-update cif.project_revision set change_status = 'committed' where id in (1,2,4,6);
+set jwt.claims.sub to '00000000-0000-0000-0000-000000000000';
+
+-- Commit / Update Revisions as user 1.
+update cif.project_revision set change_status = 'committed' where id in (1,2,4);
 
 alter table cif.form_change disable trigger _100_committed_changes_are_immutable;
 alter table cif.form_change disable trigger _100_timestamps;
 
 -- Ensure the updated_at timestamps make sense (Not all are updated at the same time, group and stagger the updates by revision)
 update cif.form_change set updated_at = updated_at + interval '1 hour' where id in (1,2,3);
-update cif.form_change set updated_at = updated_at + interval '2 hours' where id in (4,5,10);
-update cif.form_change set updated_at = updated_at + interval '3 hours' where id in (6,7,11);
-update cif.form_change set updated_at = updated_at + interval '5 hours' where id in (8,9);
+update cif.form_change set updated_at = updated_at + interval '2 hours' where id in (4,5,6);
+update cif.form_change set updated_at = updated_at + interval '3 hours' where id in (7,8,9,10);
+update cif.form_change set updated_at = updated_at + interval '4 hours' where id  = 11;
 
--- with record as (
--- select row(project_revision.*)::cif.project_revision
---       from cif.project_revision where id=3
---     ) select (r).form_change.new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r;
+-- Update revsiion 12 as user 2
+set jwt.claims.sub to '00000000-0000-0000-0000-000000000001';
+update cif.form_change set updated_at = updated_at + interval '4 hours' where id  = 12;
+
+-- return to user 1 for testing
+set jwt.claims.sub to '00000000-0000-0000-0000-000000000000';
+
+/**
+  What form_change data should be returned for each manager label record in revision 3:
+
+  1 Label: null (archived in revision 2)
+  2 Label: '{"projectId": 1, "cifUserId": 1, "projectManagerLabelId": 2}' - (updated in revision 3)
+  3 Label: null (archived in revision 3)
+  4 Label: '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 4}' - (created by user 2 in revision 3 AFTER user 1 created it in the same revision)
+
+**/
 
 /** TESTS **/
 
@@ -122,7 +144,7 @@ select set_eq(
     with record as (
       select row(project_revision.*)::cif.project_revision
       from cif.project_revision where id=3
-    ) select label::text from cif.project_revision_project_manager_form_changes_by_label((select * from record))
+    ) select (r).project_manager_label.label from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r
   $$,
   $$
     select label::text from cif.project_manager_label
@@ -132,11 +154,22 @@ select set_eq(
 
 select is(
   (
+    select count(*) from cif.form_change fc
+    join cif.project_revision pr
+      on fc.project_revision_id = pr.id
+      and pr.project_id = 1
+  ),
+  10::bigint,
+  'There are 10 total form_change records for the project with id = 1'
+);
+
+select is(
+  (
     with record as (
       select row(project_revision.*)::cif.project_revision
       from cif.project_revision where id=3
     ) select (r).form_change.new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r
-      where label='1 Label'
+      where (r).project_manager_label.label = '1 Label'
   ),
   NULL,
   'The new_form_data returned is NULL for the record with label "1 Label". It was archived in revision 2'
@@ -148,11 +181,11 @@ select is(
       select row(project_revision.*)::cif.project_revision
       from cif.project_revision where id=3
     ) select (r).form_change.new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r
-      where label='2 Label'
+      where (r).project_manager_label.label = '2 Label'
   ),
-  '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 2}'::jsonb,
+  '{"projectId": 1, "cifUserId": 1, "projectManagerLabelId": 2}'::jsonb,
   $$
-    The new_form_data returned for the record with label "2 Label" matches the data that was updated in revision 6.
+    The new_form_data returned for the record with label "2 Label" matches the data that was updated in revision 3.
     (Function returns latest committed form_change record, ordered by id if records have identical updated_at values)
   $$
 );
@@ -163,7 +196,7 @@ select is(
       select row(project_revision.*)::cif.project_revision
       from cif.project_revision where id=3
     ) select (r).form_change.new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r
-      where label='3 Label'
+      where (r).project_manager_label.label = '3 Label'
   ),
   NULL,
   $$
@@ -178,12 +211,12 @@ select is(
       select row(project_revision.*)::cif.project_revision
       from cif.project_revision where id=3
     ) select (r).form_change.new_form_data from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r
-      where label='4 Label'
+      where (r).project_manager_label.label = '4 Label'
   ),
   '{"projectId": 1, "cifUserId": 4, "projectManagerLabelId": 4}'::jsonb,
   $$
-    The new_form_data returned for the record with label "4 Label" matches the data that was created in revision 3 form_change id=11.
-    Function returns the pending form_change with id=11 in favor of the form_change with id=3. Checks that in the case of concurrent editing, the latest pending record is returned (by updated_at, id))
+    The new_form_data returned for the record with label "4 Label" matches the data that was created in revision 3 form_change id=12.
+    Function returns the pending form_change with id=12 in favor of the form_change with id=7. Checks that in the case of concurrent editing, the latest pending record is returned (by updated_at, id))
   $$
 );
 
@@ -193,7 +226,7 @@ select is(
       select row(project_revision.*)::cif.project_revision
       from cif.project_revision where id=3
     ) select count(*) from cif.project_revision_project_manager_form_changes_by_label((select * from record)) r
-      where cast((r).form_change.new_form_data->>'projectId' as integer) = 2
+      where ((r).form_change.new_form_data->'projectId')::int = 2
   ),
   0::bigint,
   'Only returns data for the project matching the project_revision''s project_id. (Does not return data from other projects)'

--- a/schema/test/unit/mutations/create_project_test.sql
+++ b/schema/test/unit/mutations/create_project_test.sql
@@ -60,7 +60,7 @@ select is(
 -- prepopulates the project manager form with the project id
 select is(
   (select new_form_data from cif.form_change where form_data_table_name='project_manager' and project_revision_id=2),
-  '{ "projectId": 1235 }'::jsonb,
+  '{ "projectId": 1235, "projectManagerLabelId": 1 }'::jsonb,
   'Populates the project_manager form with the project id'
 );
 


### PR DESCRIPTION
simplify the computed column to reflect the pattern - form changes are copied across revisions

I have temporarily hardcoded a projectManagerLabelId value in create_project() to unblock project creation. This code block will be removed in the front-end focused part of this PR since creat_project() should not create a form_change for managers by default.