### PR TITLE
fix: mark the relay store as stale when committing a form_change

### DIFF
--- a/app/lib/pages/relayFormPageFactory.tsx
+++ b/app/lib/pages/relayFormPageFactory.tsx
@@ -111,6 +111,11 @@ const relayFormPageFactory = (
           router.push(onSubmitOrDiscardRoute);
         },
         onError: (e) => console.log(e),
+        updater: (store) => {
+          // Invalidate the entire store, to make sure that we don't display any stale data after redirecting to the next page.
+          // This could be optimized to only invalidate the affected records.
+          store.invalidateStore();
+        },
       });
     };
 

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -121,6 +121,11 @@ export function ProjectRevision({
       onCompleted: async () => {
         await router.push(getProjectsPageRoute());
       },
+      updater: (store) => {
+        // Invalidate the entire store,to make sure that we don't display any stale data after redirecting to the next page.
+        // This could be optimized to only invalidate the affected records.
+        store.invalidateStore();
+      },
     });
   };
 

--- a/app/tests/unit/lib/pages/relayFormPageFactory.test.tsx
+++ b/app/tests/unit/lib/pages/relayFormPageFactory.test.tsx
@@ -243,6 +243,7 @@ describe("The relay form page factory", () => {
       debounceKey: "test-cif-form-id",
       onError: expect.any(Function),
       onCompleted: expect.any(Function),
+      updater: expect.any(Function),
       variables: {
         input: {
           formChangePatch: {

--- a/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
@@ -183,6 +183,7 @@ describe("The Create Project page", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({
       onCompleted: expect.any(Function),
+      updater: expect.any(Function),
       variables: {
         input: {
           id: "mock-proj-rev-id",


### PR DESCRIPTION
Given that committing a `form_change` record may affect many different entities, because of the use of triggers, I'm going the nuclear route here and invalidating the entire relay store. The alternative is only invalidating the records/connections that are affected, but that sounds like a lot of work to optimize this, and the scale we'll be operating at doesn't warrant this.