### PR TITLE
Remove blank loading page when data is loading

### DIFF
--- a/app/components/Layout/LoadingFallback.tsx
+++ b/app/components/Layout/LoadingFallback.tsx
@@ -1,0 +1,56 @@
+import StaticLayout from "./StaticLayout";
+
+const LoadingFallback = () => {
+  return (
+    <StaticLayout showSubheader>
+      <div className="shimmer-wrapper">
+        <div className="shimmer-line" />
+        <div className="shimmer-line" />
+        <div className="shimmer-line" />
+      </div>
+      <style jsx>{`
+        .shimmer-line {
+          height: 20px;
+          margin-top: 20px;
+          background: #777;
+          border-radius: 8px;
+          animation: shimmer-animation 2s infinite linear;
+          background: linear-gradient(
+            to right,
+            #eff1f3 4%,
+            #e2e2e2 25%,
+            #eff1f3 36%
+          );
+          background-size: 1000px 100%;
+        }
+
+        .shimmer-wrapper {
+          width: 30vw;
+          height: 100%;
+          animation: shimmer-full-view 0.5s forwards
+            cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        @keyframes shimmer-full-view {
+          0% {
+            background-position: -1000px 0;
+          }
+          100% {
+            background-position: 1000px 0;
+          }
+        }
+
+        @keyframes shimmer-animation {
+          0% {
+            background-position: -1000px 0;
+          }
+          100% {
+            background-position: 1000px 0;
+          }
+        }
+      `}</style>
+    </StaticLayout>
+  );
+};
+
+export default LoadingFallback;

--- a/app/components/Layout/Navigation.tsx
+++ b/app/components/Layout/Navigation.tsx
@@ -8,6 +8,7 @@ import SubHeader from "./SubHeader";
 
 interface Props {
   isLoggedIn?: boolean;
+  alwaysShowSubheader?: boolean;
   isAdmin?: boolean;
   children?: React.ReactNode;
   title?: string;
@@ -19,6 +20,7 @@ const DEFAULT_MOBILE_BREAK_POINT = "900";
 
 const Navigation: React.FC<Props> = ({
   isLoggedIn = false,
+  alwaysShowSubheader = false,
   title = "CleanBC Industry Fund",
   userProfileComponent,
   hideLoginButton,
@@ -66,7 +68,7 @@ const Navigation: React.FC<Props> = ({
             {rightSide}
           </BaseHeader.Group>
         </BaseHeader>
-        {isLoggedIn && <SubHeader />}
+        {(isLoggedIn || alwaysShowSubheader) && <SubHeader />}
       </BaseNavigation>
       <style jsx>{`
         h1 {

--- a/app/components/Layout/StaticLayout.tsx
+++ b/app/components/Layout/StaticLayout.tsx
@@ -7,12 +7,21 @@ const runtimeConfig = getConfig()?.publicRuntimeConfig ?? {};
 
 interface Props {
   title?: string;
+  showSubheader?: boolean;
 }
 
-const StaticLayout: React.FC<Props> = ({ children, title }) => {
+const StaticLayout: React.FC<Props> = ({
+  children,
+  title,
+  showSubheader = false,
+}) => {
   return (
     <div id="page-wrap">
-      <Navigation title={title} hideLoginButton={true}>
+      <Navigation
+        title={title}
+        hideLoginButton={true}
+        alwaysShowSubheader={showSubheader}
+      >
         {runtimeConfig.SITEWIDE_NOTICE && (
           <SiteNoticeBanner content={runtimeConfig.SITEWIDE_NOTICE} />
         )}

--- a/app/components/Table/FilterRow.tsx
+++ b/app/components/Table/FilterRow.tsx
@@ -5,12 +5,14 @@ import { TableFilter, FilterArgs } from "./Filters";
 interface Props {
   filters: TableFilter[];
   filterArgs: FilterArgs;
+  disabled?: boolean;
   onSubmit: (searchData: Record<string, string | number | boolean>) => void;
 }
 
 const FilterRow: React.FunctionComponent<Props> = ({
   filters,
   filterArgs,
+  disabled,
   onSubmit,
 }) => {
   const [searchFilters, setSearchFilters] = useState(filterArgs);
@@ -38,17 +40,23 @@ const FilterRow: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <tr onKeyDown={handleKeyDown}>
+    <tr onKeyDown={handleKeyDown} aria-disabled={disabled}>
       {filters.map((filter) => (
         <filter.Component
           key={filter.argName + filter.title}
           filterArgs={searchFilters}
+          disabled={disabled}
           onChange={handleFilterChange}
         />
       ))}
       <td>
         <div className="flex">
-          <Button variant="secondary" size="small" onClick={clearForm}>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={clearForm}
+            disabled={disabled}
+          >
             Clear
           </Button>
           <Button
@@ -56,6 +64,7 @@ const FilterRow: React.FunctionComponent<Props> = ({
             size="small"
             variant="primary"
             onClick={() => onSubmit(searchFilters)}
+            disabled={disabled}
           >
             Apply
           </Button>

--- a/app/components/Table/Filters/EnumFilter.tsx
+++ b/app/components/Table/Filters/EnumFilter.tsx
@@ -28,11 +28,12 @@ export default class EnumFilter<T> extends TableFilter {
 
   searchOptionValues: Array<{ display: string; value: T }>;
 
-  Component: FilterComponent = ({ filterArgs, onChange }) => {
+  Component: FilterComponent = ({ filterArgs, disabled, onChange }) => {
     return (
       <td>
         <Dropdown
           name={this.argName}
+          disabled={disabled}
           value={(filterArgs[this.argName] ?? "") as string}
           aria-label={`Filter by ${this.title}`}
           onChange={(evt) =>

--- a/app/components/Table/Filters/TableFilter.tsx
+++ b/app/components/Table/Filters/TableFilter.tsx
@@ -50,7 +50,7 @@ export default abstract class TableFilter<T = string | number | boolean> {
 
   castValue: (value: string) => T = (value) => value as any;
 
-  Component: FilterComponent = ({ filterArgs, onChange }) => {
+  Component: FilterComponent = ({ filterArgs, disabled, onChange }) => {
     return (
       <td>
         <Input
@@ -59,6 +59,7 @@ export default abstract class TableFilter<T = string | number | boolean> {
           size="small"
           value={(filterArgs[this.argName] ?? "") as string}
           aria-label={`Filter by ${this.title}`}
+          disabled={disabled}
           onChange={(evt) =>
             onChange(this.castValue(evt.target.value) as any, this.argName)
           }

--- a/app/components/Table/Filters/types.tsx
+++ b/app/components/Table/Filters/types.tsx
@@ -7,6 +7,7 @@ export interface PageArgs {
 
 export interface FilterComponentProps {
   onChange: (value: string | number | boolean, argName: string) => void;
+  disabled?: boolean;
   filterArgs: FilterArgs;
 }
 

--- a/app/components/Table/Pagination.tsx
+++ b/app/components/Table/Pagination.tsx
@@ -90,7 +90,11 @@ const FilterableTablePagination: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <td aria-disabled={disabled} className={disabled ? "disabled" : ""}>
+    <td
+      colSpan={1000}
+      aria-disabled={disabled}
+      className={disabled ? "disabled" : ""}
+    >
       <PaginationUnstyled
         component="div"
         count={totalCount}

--- a/app/components/Table/Pagination.tsx
+++ b/app/components/Table/Pagination.tsx
@@ -15,6 +15,7 @@ interface Props {
    * The number of items to skip to get to the current page. Defaults to 0
    */
   offset?: number;
+  disabled;
   onOffsetChange: (offset: number) => void;
   onPageSizeChange: (pageSize: number) => void;
 }
@@ -72,6 +73,7 @@ const FilterableTablePagination: React.FunctionComponent<Props> = ({
   totalCount,
   pageSize = DEFAULT_PAGE_SIZE,
   offset = 0,
+  disabled,
   onOffsetChange,
   onPageSizeChange,
 }) => {
@@ -88,8 +90,9 @@ const FilterableTablePagination: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <>
+    <td aria-disabled={disabled} className={disabled ? "disabled" : ""}>
       <PaginationUnstyled
+        component="div"
         count={totalCount}
         page={activePage}
         rowsPerPage={pageSize}
@@ -100,7 +103,14 @@ const FilterableTablePagination: React.FunctionComponent<Props> = ({
         components={paginationComponents}
         componentsProps={paginationComponentsProps as any}
       />
-    </>
+      <style jsx>{`
+        .disabled {
+          cursor: not-allowed;
+          pointer-events: none;
+          opacity: 0.5;
+        }
+      `}</style>
+    </td>
   );
 };
 

--- a/app/components/Table/SortableHeader.tsx
+++ b/app/components/Table/SortableHeader.tsx
@@ -11,7 +11,7 @@ interface Props {
   orderByPrefix?: string;
   displayName: string;
   sortable?: boolean;
-  disabled?: boolean;
+  loading?: boolean;
   onRouteUpdate: (url: any, mode: "replace" | "push") => void;
 }
 
@@ -33,7 +33,7 @@ const SortableHeader: React.FC<Props> = ({
   orderByPrefix,
   displayName,
   sortable,
-  disabled,
+  loading,
   onRouteUpdate,
 }) => {
   const router = useRouter();
@@ -76,8 +76,8 @@ const SortableHeader: React.FC<Props> = ({
     <th
       onClick={() => sortable && handleClick()}
       aria-sort={sortDirection}
-      className={disabled ? "disabled" : ""}
-      aria-disabled={disabled}
+      className={loading ? "loading" : ""}
+      aria-disabled={loading}
     >
       {displayName}&nbsp;
       {sortable && (
@@ -114,10 +114,26 @@ const SortableHeader: React.FC<Props> = ({
           border-top: 1px solid #003366;
         }
 
-        .disabled {
+        .loading {
           cursor: not-allowed;
           pointer-events: none;
-          opacity: 0.5;
+          animation: shimmer-animation 2s infinite linear;
+          background: linear-gradient(
+            to right,
+            #003366 4%,
+            #38598a 25%,
+            #003366 36%
+          );
+          background-size: 500px 100%;
+        }
+
+        @keyframes shimmer-animation {
+          0% {
+            background-position: -500px 0;
+          }
+          100% {
+            background-position: 500px 0;
+          }
         }
       `}</style>
     </th>

--- a/app/components/Table/SortableHeader.tsx
+++ b/app/components/Table/SortableHeader.tsx
@@ -11,6 +11,8 @@ interface Props {
   orderByPrefix?: string;
   displayName: string;
   sortable?: boolean;
+  disabled?: boolean;
+  onRouteUpdate: (url: any, mode: "replace" | "push") => void;
 }
 
 const SORT_DIRECTIONS = {
@@ -31,6 +33,8 @@ const SortableHeader: React.FC<Props> = ({
   orderByPrefix,
   displayName,
   sortable,
+  disabled,
+  onRouteUpdate,
 }) => {
   const router = useRouter();
 
@@ -66,10 +70,15 @@ const SortableHeader: React.FC<Props> = ({
       },
     };
 
-    router.replace(url, url, { shallow: true });
+    onRouteUpdate(url, "replace");
   };
   return (
-    <th onClick={() => sortable && handleClick()} aria-sort={sortDirection}>
+    <th
+      onClick={() => sortable && handleClick()}
+      aria-sort={sortDirection}
+      className={disabled ? "disabled" : ""}
+      aria-disabled={disabled}
+    >
       {displayName}&nbsp;
       {sortable && (
         <FontAwesomeIcon
@@ -77,8 +86,8 @@ const SortableHeader: React.FC<Props> = ({
           icon={SORT_DIRECTIONS[sortDirection].icon}
         />
       )}
-      <style>{`
-        table.bc-table th {
+      <style jsx>{`
+        th {
           position: relative;
           cursor: pointer;
           background-color: #003366;
@@ -96,6 +105,7 @@ const SortableHeader: React.FC<Props> = ({
           border-top-left-radius: 0.25rem;
           border-left: 1px solid #003366;
           border-top: 1px solid #003366;
+          padding: 0.5rem;
         }
 
         th:last-child {
@@ -104,10 +114,10 @@ const SortableHeader: React.FC<Props> = ({
           border-top: 1px solid #003366;
         }
 
-        span[role="button"] {
-          height: 100%;
-          position: absolute;
-          right: 0.75em;
+        .disabled {
+          cursor: not-allowed;
+          pointer-events: none;
+          opacity: 0.5;
         }
       `}</style>
     </th>

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -7,6 +7,7 @@ import {
   GraphQLTaggedNode,
   useRelayEnvironment,
 } from "react-relay";
+import Sentry from "@sentry/react";
 import FilterRow from "./FilterRow";
 import { FilterArgs, PageArgs, TableFilter } from "./Filters";
 import Pagination from "./Pagination";
@@ -78,9 +79,12 @@ const Table: React.FC<Props> = ({
         { fetchPolicy: "store-or-network" }
       ).subscribe({
         complete: afterFetch,
-        // if the query fails, we still want to update the route,
-        // which will retry the query and let a 500 page be rendered if it fails again
-        error: afterFetch,
+        error: (error) => {
+          Sentry.captureException(error);
+          // if the query fails, we still want to update the route,
+          // which will retry the query and let a 500 page be rendered if it fails again
+          afterFetch();
+        },
       });
     },
     [environment, isRefetching, router, pageQuery]

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -17,6 +17,12 @@ interface Props {
   paginated?: boolean;
   totalRowCount?: number;
   emptyStateContents?: JSX.Element | string;
+  /**
+   * The top-level query used by the page rendenring the table.
+   * If provided, when the table filters, ordering or pagination are updated,
+   * the table will reload the query before updating the router,
+   * preventing a render with the Suspense fallback while the new data is being fetched.
+   */
   pageQuery?: GraphQLTaggedNode;
 }
 
@@ -64,6 +70,7 @@ const Table: React.FC<Props> = ({
 
       // fetchQuery will fetch the query and write the data to the Relay store.
       // This will ensure that when we re-render, the data is already cached and we don't suspend
+      // See https://github.com/facebook/relay/blob/b8e78ca0fbbfe05f34b4854484df574d91ba2113/website/docs/guided-tour/refetching/refetching-queries-with-different-data.md#if-you-need-to-avoid-suspense
       fetchQuery(
         environment,
         pageQuery,

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -144,7 +144,7 @@ const Table: React.FC<Props> = ({
                 orderByPrefix={filter.orderByPrefix}
                 displayName={filter.title}
                 sortable={filter.isSortEnabled}
-                disabled={isRefetching}
+                loading={isRefetching}
                 onRouteUpdate={handleRouteUpdate}
               />
             ))}

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -74,7 +74,8 @@ const Table: React.FC<Props> = ({
       fetchQuery(
         environment,
         pageQuery,
-        withRelayOptions.variablesFromContext(url)
+        withRelayOptions.variablesFromContext(url),
+        { fetchPolicy: "store-or-network" }
       ).subscribe({
         complete: afterFetch,
         // if the query fails, we still want to update the route,

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -1,6 +1,12 @@
+import withRelayOptions from "lib/relay/withRelayOptions";
 import safeJsonParse from "lib/safeJsonParse";
 import { useRouter } from "next/router";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  fetchQuery,
+  GraphQLTaggedNode,
+  useRelayEnvironment,
+} from "react-relay";
 import FilterRow from "./FilterRow";
 import { FilterArgs, PageArgs, TableFilter } from "./Filters";
 import Pagination from "./Pagination";
@@ -11,6 +17,7 @@ interface Props {
   paginated?: boolean;
   totalRowCount?: number;
   emptyStateContents?: JSX.Element | string;
+  pageQuery?: GraphQLTaggedNode;
 }
 
 const Table: React.FC<Props> = ({
@@ -18,8 +25,11 @@ const Table: React.FC<Props> = ({
   paginated,
   totalRowCount,
   children,
+  pageQuery,
   emptyStateContents = <span className="no-results">No results found.</span>,
 }) => {
+  const environment = useRelayEnvironment();
+  const [isRefetching, setIsRefetching] = useState(false);
   const router = useRouter();
   const filterArgs = useMemo<FilterArgs>(
     () => safeJsonParse(router.query.filterArgs as string),
@@ -29,6 +39,43 @@ const Table: React.FC<Props> = ({
   const { offset, pageSize } = useMemo<PageArgs>(
     () => safeJsonParse(router.query.pageArgs as string),
     [router]
+  );
+
+  const handleRouteUpdate = useCallback(
+    (url, mode: "replace" | "push") => {
+      const afterFetch = () => {
+        setIsRefetching(false);
+        // At this point the data for the query should be cached,
+        // so we can update the route and re-render without suspending
+        if (mode === "replace") router.replace(url, url, { shallow: true });
+        else router.push(url, url, { shallow: true });
+      };
+
+      if (!pageQuery) {
+        afterFetch();
+        return;
+      }
+
+      if (isRefetching) {
+        return;
+      }
+
+      setIsRefetching(true);
+
+      // fetchQuery will fetch the query and write the data to the Relay store.
+      // This will ensure that when we re-render, the data is already cached and we don't suspend
+      fetchQuery(
+        environment,
+        pageQuery,
+        withRelayOptions.variablesFromContext(url)
+      ).subscribe({
+        complete: afterFetch,
+        // if the query fails, we still want to update the route,
+        // which will retry the query and let a 500 page be rendered if it fails again
+        error: afterFetch,
+      });
+    },
+    [environment, isRefetching, router, pageQuery]
   );
 
   const applyFilterArgs = (newFilterArgs: FilterArgs) => {
@@ -54,7 +101,7 @@ const Table: React.FC<Props> = ({
       },
     };
 
-    router.push(url, url, { shallow: true });
+    handleRouteUpdate(url, "push");
   };
 
   const applyPageArgs = (newPageArgs: PageArgs) => {
@@ -65,7 +112,7 @@ const Table: React.FC<Props> = ({
         pageArgs: JSON.stringify(newPageArgs),
       },
     };
-    router.push(url, url, { shallow: true });
+    handleRouteUpdate(url, "push");
   };
 
   const handleOffsetChange = (value: number) => {
@@ -90,6 +137,8 @@ const Table: React.FC<Props> = ({
                 orderByPrefix={filter.orderByPrefix}
                 displayName={filter.title}
                 sortable={filter.isSortEnabled}
+                disabled={isRefetching}
+                onRouteUpdate={handleRouteUpdate}
               />
             ))}
           </tr>
@@ -97,6 +146,7 @@ const Table: React.FC<Props> = ({
           <FilterRow
             filterArgs={filterArgs}
             filters={filters}
+            disabled={isRefetching}
             onSubmit={applyFilterArgs}
           />
         </thead>
@@ -116,6 +166,7 @@ const Table: React.FC<Props> = ({
                 totalCount={totalRowCount}
                 offset={offset}
                 pageSize={pageSize}
+                disabled={isRefetching}
                 onOffsetChange={handleOffsetChange}
                 onPageSizeChange={handleMaxResultsChange}
               />

--- a/app/lib/relay/withRelayOptions.tsx
+++ b/app/lib/relay/withRelayOptions.tsx
@@ -7,9 +7,10 @@ import { WiredOptions } from "relay-nextjs/wired/component";
 import { NextRouter } from "next/router";
 import safeJsonParse from "lib/safeJsonParse";
 import { DEFAULT_PAGE_SIZE } from "components/Table/Pagination";
+import LoadingFallback from "components/Layout/LoadingFallback";
 
 const withRelayOptions: WiredOptions<any> = {
-  fallback: <div>Loading...</div>,
+  fallback: <LoadingFallback />,
   createClientEnvironment: () => getClientEnvironment()!,
   createServerEnvironment: async (ctx: NextPageContext) => {
     const { createServerEnvironment } = await import("./server");

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -11,6 +11,7 @@ import ErrorFallback from "./500";
 import "normalize.css";
 import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
+import LoadingFallback from "components/Layout/LoadingFallback";
 config.autoAddCss = false;
 
 const clientEnv = getClientEnvironment();
@@ -24,7 +25,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   const component =
     typeof window !== "undefined" ? (
-      <Suspense fallback="loading">
+      <Suspense fallback={<LoadingFallback />}>
         <Component {...pageProps} {...relayProps} />
       </Suspense>
     ) : (

--- a/app/pages/cif/contacts.tsx
+++ b/app/pages/cif/contacts.tsx
@@ -61,6 +61,7 @@ const tableFilters = [
 function Contacts({ preloadedQuery }: RelayProps<{}, contactsQuery>) {
   const { session, allContacts, pendingNewContactFormChange } =
     usePreloadedQuery(pageQuery, preloadedQuery);
+
   const router = useRouter();
   const [addContact, isAddingContact] = useCreateNewContactFormChange();
 
@@ -97,6 +98,7 @@ function Contacts({ preloadedQuery }: RelayProps<{}, contactsQuery>) {
         paginated
         totalRowCount={allContacts.totalCount}
         filters={tableFilters}
+        pageQuery={pageQuery}
       >
         {allContacts.edges.map(({ node }) => (
           <ContactTableRow key={node.id} contact={node} />

--- a/app/pages/cif/operators.tsx
+++ b/app/pages/cif/operators.tsx
@@ -102,6 +102,7 @@ export function Operators({ preloadedQuery }: RelayProps<{}, operatorsQuery>) {
         paginated
         totalRowCount={allOperators.totalCount}
         filters={tableFilters}
+        pageQuery={OperatorsQuery}
       >
         {allOperators.edges.map(({ node }) => (
           <OperatorTableRow key={node.id} operator={node} />

--- a/app/pages/cif/projects.tsx
+++ b/app/pages/cif/projects.tsx
@@ -120,6 +120,7 @@ export function Projects({ preloadedQuery }: RelayProps<{}, projectsQuery>) {
         paginated
         totalRowCount={allProjects.totalCount}
         filters={tableFilters}
+        pageQuery={ProjectsQuery}
       >
         {allProjects.edges.map(({ node }) => (
           <ProjectTableRow key={node.id} project={node} />

--- a/app/tests/unit/components/Table/index.test.tsx
+++ b/app/tests/unit/components/Table/index.test.tsx
@@ -1,8 +1,13 @@
+/* eslint-disable relay/graphql-naming */
+// eslint and the relay compiler are conflicting here.
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import Table from "components/Table";
 import { DisplayOnlyFilter, TextFilter } from "components/Table/Filters";
 import { useRouter } from "next/router";
 import { mocked } from "jest-mock";
+import { graphql } from "relay-runtime";
+import { RelayEnvironmentProvider } from "react-relay";
+import { createMockEnvironment } from "relay-test-utils";
 jest.mock("next/router");
 
 const routerPush = jest.fn();
@@ -12,24 +17,40 @@ mocked(useRouter).mockReturnValue({
   push: routerPush,
 } as any);
 
+const pageQuery = graphql`
+  query indexTableQuery @relay_test_operation {
+    query {
+      __typename
+    }
+  }
+`;
+
+let environment;
+
 describe("The Table Component", () => {
+  beforeEach(() => {
+    environment = createMockEnvironment();
+  });
+
   it("renders the provided columns and rows", () => {
     render(
-      <Table
-        filters={[
-          new DisplayOnlyFilter("col A"),
-          new DisplayOnlyFilter("col B"),
-        ]}
-      >
-        <tr>
-          <td>A 1</td>
-          <td>B 1</td>
-        </tr>
-        <tr>
-          <td>A 2</td>
-          <td>B 2</td>
-        </tr>
-      </Table>
+      <RelayEnvironmentProvider environment={environment}>
+        <Table
+          filters={[
+            new DisplayOnlyFilter("col A"),
+            new DisplayOnlyFilter("col B"),
+          ]}
+        >
+          <tr>
+            <td>A 1</td>
+            <td>B 1</td>
+          </tr>
+          <tr>
+            <td>A 2</td>
+            <td>B 2</td>
+          </tr>
+        </Table>
+      </RelayEnvironmentProvider>
     );
 
     ["col A", "col B", "A 1", "B 1", "A 2", "B 2"].forEach((text) =>
@@ -39,13 +60,15 @@ describe("The Table Component", () => {
 
   it("renders the provided empty state contents when there are no rows", () => {
     render(
-      <Table
-        filters={[
-          new DisplayOnlyFilter("col A"),
-          new DisplayOnlyFilter("col B"),
-        ]}
-        emptyStateContents="nothing to see here"
-      />
+      <RelayEnvironmentProvider environment={environment}>
+        <Table
+          filters={[
+            new DisplayOnlyFilter("col A"),
+            new DisplayOnlyFilter("col B"),
+          ]}
+          emptyStateContents="nothing to see here"
+        />
+      </RelayEnvironmentProvider>
     );
 
     expect(screen.getByText("nothing to see here")).toBeInTheDocument();
@@ -53,21 +76,23 @@ describe("The Table Component", () => {
 
   it("updates the query string when pagination component changes pages", () => {
     render(
-      <Table
-        filters={[
-          new DisplayOnlyFilter("col A"),
-          new DisplayOnlyFilter("col B"),
-        ]}
-        paginated
-        totalRowCount={50}
-      >
-        {new Array(50).map((_, index) => (
-          <tr key={index}>
-            <td>A 1</td>
-            <td>B 1</td>
-          </tr>
-        ))}
-      </Table>
+      <RelayEnvironmentProvider environment={environment}>
+        <Table
+          filters={[
+            new DisplayOnlyFilter("col A"),
+            new DisplayOnlyFilter("col B"),
+          ]}
+          paginated
+          totalRowCount={50}
+        >
+          {new Array(50).map((_, index) => (
+            <tr key={index}>
+              <td>A 1</td>
+              <td>B 1</td>
+            </tr>
+          ))}
+        </Table>
+      </RelayEnvironmentProvider>
     );
 
     fireEvent.click(screen.getByTitle(/go to next page/i));
@@ -86,19 +111,21 @@ describe("The Table Component", () => {
 
   it("updates the query string when a filter is applied", () => {
     render(
-      <Table
-        filters={[
-          new TextFilter("col A", "colA"),
-          new DisplayOnlyFilter("col B"),
-        ]}
-      >
-        {new Array(50).map((_, index) => (
-          <tr key={index}>
-            <td>A 1</td>
-            <td>B 1</td>
-          </tr>
-        ))}
-      </Table>
+      <RelayEnvironmentProvider environment={environment}>
+        <Table
+          filters={[
+            new TextFilter("col A", "colA"),
+            new DisplayOnlyFilter("col B"),
+          ]}
+        >
+          {new Array(50).map((_, index) => (
+            <tr key={index}>
+              <td>A 1</td>
+              <td>B 1</td>
+            </tr>
+          ))}
+        </Table>
+      </RelayEnvironmentProvider>
     );
 
     act(() => {
@@ -107,6 +134,59 @@ describe("The Table Component", () => {
       });
     });
     fireEvent.click(screen.getByText(/apply/i));
+
+    const expectedRoute = {
+      pathname: "/",
+      query: {
+        filterArgs: JSON.stringify({ colA: "A" }),
+        pageArgs: JSON.stringify({ offset: 0 }),
+      },
+    };
+
+    expect(routerPush).toHaveBeenCalledWith(expectedRoute, expectedRoute, {
+      shallow: true,
+    });
+  });
+
+  it("when given a pageQuery prop, pre-fetches the query with the new variables", () => {
+    render(
+      <RelayEnvironmentProvider environment={environment}>
+        <Table
+          pageQuery={pageQuery}
+          filters={[
+            new TextFilter("col A", "colA"),
+            new DisplayOnlyFilter("col B"),
+          ]}
+        >
+          {new Array(50).map((_, index) => (
+            <tr key={index}>
+              <td>A 1</td>
+              <td>B 1</td>
+            </tr>
+          ))}
+        </Table>
+      </RelayEnvironmentProvider>
+    );
+
+    act(() => {
+      fireEvent.change(screen.getByPlaceholderText(/filter/i), {
+        target: { value: "A" },
+      });
+    });
+    fireEvent.click(screen.getByText(/apply/i));
+
+    expect(screen.getByPlaceholderText(/filter/i)).toBeDisabled();
+    expect(screen.getByText(/apply/i)).toBeDisabled();
+
+    expect(routerPush).not.toHaveBeenCalled();
+    act(() => {
+      environment.mock.resolveMostRecentOperation(() => ({
+        data: { query: { id: "abc", __typename: "Query" } },
+      }));
+    });
+
+    expect(screen.getByPlaceholderText(/filter/i)).toBeEnabled();
+    expect(screen.getByText(/apply/i)).toBeEnabled();
 
     const expectedRoute = {
       pathname: "/",


### PR DESCRIPTION
- Added a `LoadingFallback` for transitions between pages
- `Table` component pre-fetches the data before updating the router, following the [behaviour described in the relay docs](https://relay.dev/docs/guided-tour/refetching/refetching-queries-with-different-data/#if-you-need-to-avoid-suspense-1)