### PR TITLE
PO review update: display project manager names in desired order

### DIFF
--- a/app/components/Project/ProjectTableRow.tsx
+++ b/app/components/Project/ProjectTableRow.tsx
@@ -31,7 +31,7 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
         projectStatusByProjectStatusId {
           name
         }
-        projectManagersByProjectId {
+        projectManagersByProjectId(orderBy: PROJECT_MANAGER_LABEL_ID_ASC) {
           edges {
             node {
               cifUserByCifUserId {

--- a/app/pages/cif/project/[project]/index.tsx
+++ b/app/pages/cif/project/[project]/index.tsx
@@ -43,7 +43,7 @@ export const pageQuery = graphql`
           }
         }
       }
-      projectManagersByProjectId {
+      projectManagersByProjectId(orderBy: PROJECT_MANAGER_LABEL_ID_ASC) {
         edges {
           node {
             cifUserByCifUserId {


### PR DESCRIPTION
See PO comments in https://github.com/bcgov/cas-cif/issues/337. The project manager names should show up in the same order they were entered when creating a project.