### PR TITLE
chore: pull docker images through Artifactory

### DIFF
--- a/chart/cas-cif/templates/_helpers.tpl
+++ b/chart/cas-cif/templates/_helpers.tpl
@@ -74,3 +74,10 @@ Gets the suffix of the namespace. (-dev, -tools, ... )
 {{- define "cas-cif.namespaceSuffix" }}
 {{- (split "-" .Release.Namespace)._1 | trim -}}
 {{- end }}
+
+
+{{- define "cas-cif.imagePullSecrets" }}
+{{- $artSa := (lookup "artifactory.devops.gov.bc.ca/v1alpha1" "ArtifactoryServiceAccount" .Release.Namespace .Values.artifactoryServiceAccount) }}
+{{- $artPullSecretSuffix := $artSa.spec.current_plate }}
+- name: artifacts-pull-{{ .Values.artifactoryServiceAccount }}-{{ $artPullSecretSuffix }}
+{{- end }}

--- a/chart/cas-cif/templates/_helpers.tpl
+++ b/chart/cas-cif/templates/_helpers.tpl
@@ -78,6 +78,12 @@ Gets the suffix of the namespace. (-dev, -tools, ... )
 
 {{- define "cas-cif.imagePullSecrets" }}
 {{- $artSa := (lookup "artifactory.devops.gov.bc.ca/v1alpha1" "ArtifactoryServiceAccount" .Release.Namespace .Values.artifactoryServiceAccount) }}
-{{- $artPullSecretSuffix := $artSa.spec.current_plate }}
-- name: artifacts-pull-{{ .Values.artifactoryServiceAccount }}-{{ $artPullSecretSuffix }}
+{{- if $artSa.spec }}
+- name: artifacts-pull-{{ .Values.artifactoryServiceAccount }}-{{ $artSa.spec.current_plate }}
+{{- else }}
+{{/*
+When running helm template, or using --dry-run, lookup returns an empty object
+*/}}
+- name: image-pull-secret-here
+{{- end }}
 {{- end }}

--- a/chart/cas-cif/templates/app-deployment.yaml
+++ b/chart/cas-cif/templates/app-deployment.yaml
@@ -71,6 +71,7 @@ spec:
               echo "Waiting 10s for migrations to complete..."
               sleep 10;
             done;
+      imagePullSecrets: {{ include "cas-cif.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ template "cas-cif.fullname" . }}
         imagePullPolicy: {{ default .Values.defaultImagePullPolicy .Values.image.app.pullPolicy }}

--- a/chart/cas-cif/templates/cronJobs/app-user.yaml
+++ b/chart/cas-cif/templates/cronJobs/app-user.yaml
@@ -16,6 +16,7 @@ spec:
         spec:
           activeDeadlineSeconds: 600
           restartPolicy: Never
+          imagePullSecrets: {{ include "cas-cif.imagePullSecrets" . | nindent 12 }}
           containers:
             - env:
                 - name: PGUSER

--- a/chart/cas-cif/templates/cronJobs/cron-swrs-operator-import.yaml
+++ b/chart/cas-cif/templates/cronJobs/cron-swrs-operator-import.yaml
@@ -20,6 +20,7 @@ spec:
         spec:
           activeDeadlineSeconds: 600
           restartPolicy: Never
+          imagePullSecrets: {{ include "cas-cif.imagePullSecrets" . | nindent 12 }}
           containers:
             - env:
                 - name: PGDATABASE

--- a/chart/cas-cif/templates/cronJobs/db-init.yaml
+++ b/chart/cas-cif/templates/cronJobs/db-init.yaml
@@ -20,6 +20,7 @@ spec:
 {{ include "cas-cif.labels" . | indent 12 }}
         spec:
           restartPolicy: Never
+          imagePullSecrets: {{ include "cas-cif.imagePullSecrets" . | nindent 12 }}
           containers:
             - env:
                 - name: PGDATABASE

--- a/chart/cas-cif/templates/cronJobs/deploy-data.yaml
+++ b/chart/cas-cif/templates/cronJobs/deploy-data.yaml
@@ -16,6 +16,7 @@ spec:
         spec:
           activeDeadlineSeconds: 600
           restartPolicy: Never
+          imagePullSecrets: {{ include "cas-cif.imagePullSecrets" . | nindent 12 }}
           containers:
             - env:
                 - name: SQITCH_TARGET

--- a/chart/cas-cif/templates/db-pre-upgrade-job.yaml
+++ b/chart/cas-cif/templates/db-pre-upgrade-job.yaml
@@ -15,6 +15,7 @@ spec:
       name: {{ template "cas-cif.fullname" . }}-db-pre-upgrade
     spec:
       restartPolicy: Never
+      imagePullSecrets: {{ include "cas-cif.imagePullSecrets" . | nindent 8 }}
       containers:
         - env:
             - name: PGDATABASE

--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -1,15 +1,16 @@
 defaultImageTag: latest # set to the GIT SHA1 in the Makefile
 defaultImagePullPolicy: IfNotPresent
+artifactoryServiceAccount: cas-artifact-download # The name of the ArtifactoryServiceAccount object created in the cas-provision chart
 
 replicaCount: 2
 
 image:
   app:
-    repository: gcr.io/ggl-cas-storage/cas-cif-app
+    repository: artifacts.developer.gov.bc.ca/google-docker-remote/ggl-cas-storage/cas-cif-app
   schema:
-    repository: gcr.io/ggl-cas-storage/cas-cif-schema
+    repository: artifacts.developer.gov.bc.ca/google-docker-remote/ggl-cas-storage/cas-cif-schema
   psql:
-    repository: gcr.io/ggl-cas-storage/cas-postgres
+    repository: artifacts.developer.gov.bc.ca/google-docker-remote/ggl-cas-storage/cas-postgres
     tag: "0.3.0"
 
 cas-postgres:


### PR DESCRIPTION
Todo: `lookup` doesn't return anything when doing a `helm template` (by design), so the helper needs to handle that to avoid throwing an exception when linting the chart