### PR TITLE
feat: use vanity urls for the app routes

### DIFF
--- a/chart/cas-cif/values-dev.yaml
+++ b/chart/cas-cif/values-dev.yaml
@@ -4,7 +4,7 @@ app:
     content: <div class="alert alert-warning">This is the DEV environment.</div>
 
 nginx-sidecar:
-  hostName: cas-cif-dev.apps.silver.devops.gov.bc.ca
+  hostName: dev.cif.gov.bc.ca
 
 db:
   preUpgradeCommand: |

--- a/chart/cas-cif/values-prod.yaml
+++ b/chart/cas-cif/values-prod.yaml
@@ -1,0 +1,14 @@
+nginx-sidecar:
+  hostName: cif.gov.bc.ca
+  caServerSecret: cas-acme-url
+  caServerKey: url
+  renewalDays: 305
+
+cert-issue:
+  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
+
+deploy-db:
+  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
+
+download-dags:
+  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values-test.yaml
+++ b/chart/cas-cif/values-test.yaml
@@ -3,7 +3,7 @@ app:
     content: <div class="alert alert-warning">This is the TEST environment.</div>
 
 nginx-sidecar:
-  hostName: cas-cif-test.apps.silver.devops.gov.bc.ca
+  hostName: test.cif.gov.bc.ca
 
 db:
   preUpgradeCommand: |


### PR DESCRIPTION
The easiest way to switch the routes in dev and test will be to uninstall and then re-install the charts