### PR TITLE
fix: postgres incremental backups should not run at 8am

### DIFF
--- a/chart/cas-cif/templates/postgres.yaml
+++ b/chart/cas-cif/templates/postgres.yaml
@@ -87,4 +87,5 @@ spec:
             bucket: {{ .Release.Namespace }}-cif-backups
           schedules:
             full: "0 8 * * *"
-            incremental: "0 */4 * * *"
+            # run incremental backup every 4 hours, except at 8am UTC (when the full backup is running)
+            incremental: "0 0,4,12,16,20 * * *"


### PR DESCRIPTION
Full backups are running at 8am, causing conflicts and jobs failing