### PR TITLE
Feat/revision change reason

### DIFF
--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -275,7 +275,7 @@ describe("the new project page", () => {
     });
     cy.get("textarea").click().type("foo");
     // Allow the component to finish saving before taking screenshot
-    cy.wait(1500);
+    cy.contains("Changes saved").should("be.visible");
     cy.get("body").happoScreenshot({
       component: "Project Revision Summary",
       variant: "with_change_reason",

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -274,6 +274,8 @@ describe("the new project page", () => {
       variant: "no_change_reason",
     });
     cy.get("textarea").click().type("foo");
+    // Allow the component to finish saving before taking screenshot
+    cy.wait(1500);
     cy.get("body").happoScreenshot({
       component: "Project Revision Summary",
       variant: "with_change_reason",

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -268,6 +268,8 @@ describe("the new project page", () => {
       .next()
       .should("have.text", "Not added");
 
+    cy.findByRole("button", { name: /submit/i }).should("be.disabled");
+    cy.get("textarea").click().type("change reason");
     cy.findByRole("button", { name: /submit/i }).click();
 
     cy.url().should("include", "/cif/projects");

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -269,7 +269,15 @@ describe("the new project page", () => {
       .should("have.text", "Not added");
 
     cy.findByRole("button", { name: /submit/i }).should("be.disabled");
-    cy.get("textarea").click().type("change reason");
+    cy.get("body").happoScreenshot({
+      component: "Project Revision Summary",
+      variant: "no_change_reason",
+    });
+    cy.get("textarea").click().type("foo");
+    cy.get("body").happoScreenshot({
+      component: "Project Revision Summary",
+      variant: "with_change_reason",
+    });
     cy.findByRole("button", { name: /submit/i }).click();
 
     cy.url().should("include", "/cif/projects");

--- a/app/mutations/ProjectRevision/updateChangeReason.ts
+++ b/app/mutations/ProjectRevision/updateChangeReason.ts
@@ -1,0 +1,24 @@
+import { graphql } from "react-relay";
+import useDebouncedMutation from "mutations/useDebouncedMutation";
+import { updateProjectRevisionMutation } from "updateProjectRevisionMutation.graphql"
+
+const mutation = graphql`
+  mutation updateChangeReasonMutation($input: UpdateProjectRevisionInput!) {
+    updateProjectRevision(input: $input) {
+      projectRevision {
+        id
+        changeReason
+        updatedAt
+      }
+    }
+  }
+`;
+
+const useUpdateChangeReason = () => {
+  return useDebouncedMutation<updateProjectRevisionMutation>(
+    mutation,
+    () => "An error occurred when updating the form."
+  );
+};
+
+export { mutation, useUpdateChangeReason };

--- a/app/mutations/ProjectRevision/updateChangeReason.ts
+++ b/app/mutations/ProjectRevision/updateChangeReason.ts
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay";
 import useDebouncedMutation from "mutations/useDebouncedMutation";
-import { updateProjectRevisionMutation } from "updateProjectRevisionMutation.graphql"
+import { updateProjectRevisionMutation } from "updateProjectRevisionMutation.graphql";
 
 const mutation = graphql`
   mutation updateChangeReasonMutation($input: UpdateProjectRevisionInput!) {

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -60,8 +60,8 @@ export function ProjectRevision({
     useDeleteProjectRevisionMutation();
 
   const lastEditedDate = useMemo(
-    () => new Date(query.projectRevision.updatedAt),
-    [query.projectRevision.updatedAt]
+    () => new Date(query.projectRevision?.updatedAt),
+    [query.projectRevision?.updatedAt]
   );
 
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -22131,6 +22131,8 @@ enum FormChangesOrderBy {
   PREVIOUS_FORM_CHANGE_ID_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  PROJECT_REVISION_BY_PROJECT_REVISION_ID__CHANGE_REASON_ASC
+  PROJECT_REVISION_BY_PROJECT_REVISION_ID__CHANGE_REASON_DESC
   PROJECT_REVISION_BY_PROJECT_REVISION_ID__CHANGE_STATUS_ASC
   PROJECT_REVISION_BY_PROJECT_REVISION_ID__CHANGE_STATUS_DESC
   PROJECT_REVISION_BY_PROJECT_REVISION_ID__CREATED_AT_ASC
@@ -30214,6 +30216,9 @@ type ProjectProjectStatusesByAttachmentProjectIdAndProjectStatusIdManyToManyEdge
 
 """Table containing all the changes for a project revision"""
 type ProjectRevision implements Node {
+  """Explanation of why the revision was made"""
+  changeReason: String
+
   """Foreign key to the status of the project revision"""
   changeStatus: String
 
@@ -30689,6 +30694,9 @@ A condition to be used against `ProjectRevision` object types. All fields are
 tested for equality and combined with a logical ‘and.’
 """
 input ProjectRevisionCondition {
+  """Checks for equality with the object’s `changeReason` field."""
+  changeReason: String
+
   """Checks for equality with the object’s `changeStatus` field."""
   changeStatus: String
 
@@ -30717,6 +30725,9 @@ A filter to be used against `ProjectRevision` object types. All fields are combi
 input ProjectRevisionFilter {
   """Checks for all expressions in this list."""
   and: [ProjectRevisionFilter!]
+
+  """Filter by the object’s `changeReason` field."""
+  changeReason: StringFilter
 
   """Filter by the object’s `changeStatus` field."""
   changeStatus: StringFilter
@@ -30842,6 +30853,9 @@ type ProjectRevisionFormChangesByFormChangeProjectRevisionIdAndPreviousFormChang
 Represents an update to a `ProjectRevision`. Fields that are set will be updated.
 """
 input ProjectRevisionPatch {
+  """Explanation of why the revision was made"""
+  changeReason: String
+
   """Foreign key to the status of the project revision"""
   changeStatus: String
 
@@ -30913,6 +30927,8 @@ type ProjectRevisionsEdge {
 
 """Methods to use when ordering `ProjectRevision`."""
 enum ProjectRevisionsOrderBy {
+  CHANGE_REASON_ASC
+  CHANGE_REASON_DESC
   CHANGE_STATUS_ASC
   CHANGE_STATUS_BY_CHANGE_STATUS__ACTIVE_ASC
   CHANGE_STATUS_BY_CHANGE_STATUS__ACTIVE_DESC

--- a/schema/data/dev/004_cif_project.sql
+++ b/schema/data/dev/004_cif_project.sql
@@ -46,7 +46,7 @@ do $$
       where project_revision_id=current_revision.id and form_data_table_name='project_contact';
 
       update cif.project_revision
-      set change_status='committed'
+      set change_reason=concat('reason for change ', index), change_status='committed'
       where id=current_revision.id;
 
     end loop;

--- a/schema/deploy/tables/project_revision.sql
+++ b/schema/deploy/tables/project_revision.sql
@@ -5,7 +5,8 @@ begin;
 create table cif.project_revision (
   id integer primary key generated always as identity,
   project_id integer references cif.project(id),
-  change_status varchar(1000) default 'pending' references cif.change_status
+  change_status varchar(1000) default 'pending' references cif.change_status,
+  change_reason varchar(10000)
 );
 
 select cif_private.upsert_timestamp_columns('cif', 'project_revision', add_archive => false);
@@ -45,5 +46,6 @@ comment on table cif.project_revision is 'Table containing all the changes for a
 comment on column cif.project_revision.id is 'Unique ID for the project revision';
 comment on column cif.project_revision.project_id is 'Foreign key to the associated project row. Will be null if the project hasn''t been committed yet.';
 comment on column cif.project_revision.change_status is 'Foreign key to the status of the project revision';
+comment on column cif.project_revision.change_reason is 'Explanation of why the revision was made';
 
 commit;

--- a/schema/deploy/trigger_functions/commit_project_revision.sql
+++ b/schema/deploy/trigger_functions/commit_project_revision.sql
@@ -7,6 +7,10 @@ returns trigger as $$
 declare
 begin
 
+  if (new.change_status='committed') and (new.project_id is not null) and (new.change_reason is null) then
+    raise exception 'Cannot commit change with change_reason %', new.change_reason;
+  end if;
+
   -- Propagate the change_status to all related form_change records
   -- Save the project table first do avoid foreign key violations from other potential tables.
   update cif.form_change

--- a/schema/deploy/trigger_functions/commit_project_revision.sql
+++ b/schema/deploy/trigger_functions/commit_project_revision.sql
@@ -8,7 +8,7 @@ declare
 begin
 
   if (new.change_status='committed') and (new.project_id is not null) and (new.change_reason is null) then
-    raise exception 'Cannot commit change with change_reason %', new.change_reason;
+    raise exception 'Cannot commit change if change_reason is null.';
   end if;
 
   -- Propagate the change_status to all related form_change records

--- a/schema/test/unit/computed_columns/form_change_parent_form_change_from_revision_test.sql
+++ b/schema/test/unit/computed_columns/form_change_parent_form_change_from_revision_test.sql
@@ -20,10 +20,10 @@ values
   (1, 1, 1, 1, '000', 'summary', 'project 1'),
   (2, 1, 1, 1, '001', 'summary', 'project 2');
 
-insert into cif.project_revision(id, change_status, project_id)
+insert into cif.project_revision(id, change_status, change_reason, project_id)
 overriding system value
 values
-  (1, 'committed', 1), (2, 'committed', 1), (3, 'committed', 1), (4, 'committed', 2), (5, 'committed', 1);
+  (1, 'committed', 'reason', 1), (2, 'committed', 'reason', 1), (3, 'committed', 'reason', 1), (4, 'committed', 'reason', 2), (5, 'committed', 'reason', 1);
 
 alter table cif.form_change disable trigger commit_form_change;
 /** END SETUP **/

--- a/schema/test/unit/computed_columns/form_change_parent_form_change_from_revision_test.sql
+++ b/schema/test/unit/computed_columns/form_change_parent_form_change_from_revision_test.sql
@@ -23,7 +23,11 @@ values
 insert into cif.project_revision(id, change_status, change_reason, project_id)
 overriding system value
 values
-  (1, 'committed', 'reason', 1), (2, 'committed', 'reason', 1), (3, 'committed', 'reason', 1), (4, 'committed', 'reason', 2), (5, 'committed', 'reason', 1);
+  (1, 'committed', 'reason for change', 1),
+  (2, 'committed', 'reason for change', 1),
+  (3, 'committed', 'reason for change', 1),
+  (4, 'committed', 'reason for change', 2),
+  (5, 'committed', 'reason for change', 1);
 
 alter table cif.form_change disable trigger commit_form_change;
 /** END SETUP **/

--- a/schema/test/unit/computed_columns/project_pending_project_revision_test.sql
+++ b/schema/test/unit/computed_columns/project_pending_project_revision_test.sql
@@ -23,13 +23,13 @@ values
   (2, 2, 1, 1, '001', 'summary', 'project 2'),
   (3, 3, 1, 1, '002', 'summary', 'project 3');
 
-insert into cif.project_revision(id, change_status, project_id)
+insert into cif.project_revision(id, change_status, change_reason, project_id)
 overriding system value
 values
-  (1, 'committed', 1),
-  (2, 'committed', 2),
-  (3, 'pending', 3),
-  (4, 'pending', 1);
+  (1, 'committed', 'reason for change', 1),
+  (2, 'committed', 'reason for change', 2),
+  (3, 'pending', 'reason for change', 3),
+  (4, 'pending', 'reason for change', 1);
 
 select is (
   (select id from cif.project_pending_project_revision(

--- a/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
+++ b/schema/test/unit/computed_columns/project_revision_project_manager_form_changes_by_label_test.sql
@@ -48,9 +48,15 @@ insert into cif.project(id, operator_id, funding_stream_rfp_id, project_status_i
     (1, 1, 1, 1, '001', 'summary', 'project 1'),
     (2, 1, 1, 1, '002', 'summary', 'project 2');
 
-insert into cif.project_revision(id, change_status, project_id)
+insert into cif.project_revision(id, change_status, change_reason, project_id)
   overriding system value
-  values (1, 'pending', 1), (2, 'pending', 1), (3, 'pending', 1), (4, 'pending', 2), (5, 'pending', 2), (6, 'pending', 1);
+  values
+    (1, 'pending', 'reason for change', 1),
+    (2, 'pending', 'reason for change', 1),
+    (3, 'pending', 'reason for change', 1),
+    (4, 'pending', 'reason for change', 2),
+    (5, 'pending', 'reason for change', 2),
+    (6, 'pending', 'reason for change', 1);
 
 /** Basic Setup End **/
 

--- a/schema/test/unit/trigger_functions/set_previous_form_change_id_test.sql
+++ b/schema/test/unit/trigger_functions/set_previous_form_change_id_test.sql
@@ -20,10 +20,13 @@ values
   (1, 1, 1, 1, '000', 'summary', 'project 1'),
   (2, 1, 1, 1, '001', 'summary', 'project 2');
 
-insert into cif.project_revision(id, change_status, project_id)
+insert into cif.project_revision(id, change_status, change_reason, project_id)
 overriding system value
 values
-  (1, 'committed', 1), (2, 'committed', 1), (3, 'committed', 1), (4, 'committed', 2);
+  (1, 'committed', 'reason for change', 1),
+  (2, 'committed', 'reason for change', 1),
+  (3, 'committed', 'reason for change', 1),
+  (4, 'committed', 'reason for change', 2);
 
 alter table cif.form_change disable trigger commit_form_change;
 /** END SETUP **/


### PR DESCRIPTION
- Added `change_reason` column to `project_revision` table.
- Added a text area to input the reason for a revision. Saves as you type using a debounced mutation. 
- Does not render if this revision is a project creation.
- If the revision is on an existing project, a change reason must be entered in order to submit the project revision.

Action shot:
![changeReason](https://user-images.githubusercontent.com/11034827/164112232-33257c15-3894-46f7-9f9d-f76ebeaaeece.gif)


Not present on a new project: 
![Screen Shot 2022-04-19 at 15 29 18](https://user-images.githubusercontent.com/11034827/164112202-33f2d9e9-c2d3-4ae1-844a-4bd87af02d70.png)

