### PR TITLE
refactor: form label is displayed by fields, not widgets

### DIFF
--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -196,18 +196,24 @@ const ProjectForm: React.FC<Props> = (props) => {
   };
 
   const schema: JSONSchema7 = useMemo(() => {
-    const initialSchema = projectSchema;
-    initialSchema.properties.operatorId.anyOf = query.allOperators.edges.map(
-      ({ node }) => {
-        return {
-          type: "number",
-          title: `${node.legalName} (${node.bcRegistryId})`,
-          enum: [node.rowId],
-          value: node.rowId,
-        };
-      }
-    );
-    initialSchema.required = [...initialSchema.required, "operatorTradeName"];
+    const initialSchema = {
+      ...projectSchema,
+      properties: {
+        ...projectSchema.properties,
+        operatorId: {
+          ...projectSchema.properties.operatorId,
+          anyOf: query.allOperators.edges.map(({ node }) => {
+            return {
+              type: "number",
+              title: `${node.legalName} (${node.bcRegistryId})`,
+              enum: [node.rowId],
+              value: node.rowId,
+            };
+          }),
+        },
+      },
+      required: [...projectSchema.required, "operatorTradeName"],
+    };
     return initialSchema as JSONSchema7;
   }, [query]);
 

--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -38,12 +38,10 @@ export const createProjectUiSchema = (
       "projectStatusId",
     ],
     proposalReference: {
-      "ui:placeholder": "2020-RFP-1-123-ABCD",
       "bcgov:size": "small",
-      "bcgov:help-text": "(e.g. 2020-RFP-1-ABCD-123)",
+      "ui:help": "(e.g. 2020-RFP-1-ABCD-123)",
     },
     projectName: {
-      "ui:placeholder": "Short project name",
       "ui:col-md": 12,
       "bcgov:size": "small",
     },
@@ -64,16 +62,15 @@ export const createProjectUiSchema = (
       "ui:widget": "SearchWidget",
       "ui:options": {
         text: `${legalName ? `${legalName} (${bcRegistryId})` : ""}`,
-        title: "Legal Operator Name and BC Registry ID",
       },
     },
     operatorTradeName: {
       "ui:col-md": 12,
       "ui:widget": "DisplayOnly",
       "bcgov:size": "small",
+      "ui:title": "Trade Name",
       "ui:options": {
         text: `${tradeName}`,
-        title: "Trade Name",
       },
     },
     fundingStreamRfpId: {
@@ -82,6 +79,7 @@ export const createProjectUiSchema = (
       "bcgov:size": "small",
       "ui:options": {
         text: `${rfpStream}`,
+        label: rfpStream ? true : false,
       },
     },
     projectStatusId: {
@@ -209,6 +207,7 @@ const ProjectForm: React.FC<Props> = (props) => {
         };
       }
     );
+    initialSchema.required = [...initialSchema.required, "operatorTradeName"];
     return initialSchema as JSONSchema7;
   }, [query]);
 

--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -19,7 +19,6 @@ interface Props {
 }
 // You only need to include the optional arguments when using this function to create the schema for the summary (read-only) page.
 export const createProjectUiSchema = (
-  tradeName,
   legalName?,
   bcRegistryId?,
   rfpStream?,
@@ -39,7 +38,7 @@ export const createProjectUiSchema = (
     ],
     proposalReference: {
       "bcgov:size": "small",
-      "ui:help": "(e.g. 2020-RFP-1-ABCD-123)",
+      "ui:help": <small>(e.g. 2020-RFP-1-ABCD-123)</small>,
     },
     projectName: {
       "ui:col-md": 12,
@@ -62,15 +61,6 @@ export const createProjectUiSchema = (
       "ui:widget": "SearchWidget",
       "ui:options": {
         text: `${legalName ? `${legalName} (${bcRegistryId})` : ""}`,
-      },
-    },
-    operatorTradeName: {
-      "ui:col-md": 12,
-      "ui:widget": "DisplayOnly",
-      "bcgov:size": "small",
-      "ui:title": "Trade Name",
-      "ui:options": {
-        text: `${tradeName}`,
       },
     },
     fundingStreamRfpId: {
@@ -212,7 +202,6 @@ const ProjectForm: React.FC<Props> = (props) => {
           }),
         },
       },
-      required: [...projectSchema.required, "operatorTradeName"],
     };
     return initialSchema as JSONSchema7;
   }, [query]);

--- a/app/components/Form/ProjectFormSummary.tsx
+++ b/app/components/Form/ProjectFormSummary.tsx
@@ -46,7 +46,6 @@ const ProjectFormSummary: React.FC<Props> = (props) => {
               node {
                 rowId
                 legalName
-                tradeName
                 bcRegistryId
               }
             }
@@ -100,7 +99,6 @@ const ProjectFormSummary: React.FC<Props> = (props) => {
           theme={readOnlyTheme}
           schema={projectSchema as JSONSchema7}
           uiSchema={createProjectUiSchema(
-            selectedOperator ? selectedOperator.node.tradeName : "",
             selectedOperator ? selectedOperator.node.legalName : "",
             selectedOperator ? selectedOperator.node.bcRegistryId : "",
             rfpStream

--- a/app/components/Form/ProjectManagerForm.tsx
+++ b/app/components/Form/ProjectManagerForm.tsx
@@ -32,9 +32,9 @@ export const createProjectManagerUiSchema = (contact?, role?) => {
       "ui:col-md": 12,
       "bcgov:size": "small",
       "ui:widget": "SearchWidget",
+      "ui:title": role,
       "ui:options": {
-        label: false,
-        title: `${role}`,
+        label: role ? true : false,
         text: `${contact}`,
       },
     },

--- a/app/components/Form/ProjectManagerForm.tsx
+++ b/app/components/Form/ProjectManagerForm.tsx
@@ -132,7 +132,6 @@ const ProjectManagerForm: React.FC<Props> = (props) => {
         label={change.projectManagerLabel.label}
         required={false}
         htmlFor={`${formIdPrefix}_cifUserId`}
-        uiSchema={uiSchema}
       />
       <div>
         <FormBase

--- a/app/components/Form/SelectProjectStatusWidget.tsx
+++ b/app/components/Form/SelectProjectStatusWidget.tsx
@@ -4,16 +4,8 @@ import { graphql, useFragment } from "react-relay";
 import Dropdown from "@button-inc/bcgov-theme/Dropdown";
 
 const SelectProjectStatus: React.FunctionComponent<WidgetProps> = (props) => {
-  const {
-    id,
-    onChange,
-    placeholder,
-    label,
-    required,
-    uiSchema,
-    value,
-    formContext,
-  } = props;
+  const { id, onChange, placeholder, required, uiSchema, value, formContext } =
+    props;
 
   const { allFundingStreamRfpProjectStatuses } = useFragment(
     graphql`
@@ -46,7 +38,6 @@ const SelectProjectStatus: React.FunctionComponent<WidgetProps> = (props) => {
 
   return (
     <div>
-      <label htmlFor={id}>{label}</label>
       <Dropdown
         id={id}
         onChange={(e) => onChange(e.target.value || undefined)}

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -77,7 +77,7 @@ describe("the new project page", () => {
       component: "Project Overview Form",
       variant: "with errors",
     });
-    cy.get(".error-detail").should("have.length", 6);
+    cy.get(".error-detail").should("have.length", 7);
     // Renders the default error message for a required field
     cy.get(".error-detail").last().should("contain", "Please enter a value");
 

--- a/app/data/jsonSchemaForm/projectSchema.ts
+++ b/app/data/jsonSchemaForm/projectSchema.ts
@@ -8,6 +8,7 @@ const projectSchema = {
     "operatorId",
     "fundingStreamRfpId",
     "totalFundingRequest",
+    "projectStatusId",
   ],
   properties: {
     proposalReference: {

--- a/app/data/jsonSchemaForm/projectSchema.ts
+++ b/app/data/jsonSchemaForm/projectSchema.ts
@@ -28,9 +28,6 @@ const projectSchema = {
       default: undefined,
       anyOf: undefined,
     },
-    operatorTradeName: {
-      type: "string",
-    },
     fundingStreamRfpId: {
       type: "number",
       title: "Funding Stream RFP ID",

--- a/app/lib/theme/ReadOnlyFieldTemplate.tsx
+++ b/app/lib/theme/ReadOnlyFieldTemplate.tsx
@@ -6,7 +6,6 @@ import FieldLabel from "./widgets/FieldLabel";
 const FieldTemplate: React.FC<FieldTemplateProps> = ({
   children,
   errors,
-  help,
   rawErrors,
   label,
   displayLabel,
@@ -15,27 +14,34 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
 }) => {
   return (
     <div>
-      {displayLabel && (
-        <FieldLabel label={label} required={required} htmlFor={id} />
-      )}
-      {help}
-      {children}
-
-      <div className="error-div">
-        {rawErrors && rawErrors.length > 0 ? (
-          <>
-            <FontAwesomeIcon
-              className="error-icon"
-              icon={faExclamationTriangle}
-            />
-            {errors}
-          </>
-        ) : null}
+      <div className="definition-container">
+        {displayLabel && (
+          <FieldLabel
+            label={label}
+            required={required}
+            htmlFor={id}
+            tagName="dt"
+          />
+        )}
+        {children}
       </div>
+      {rawErrors && rawErrors.length > 0 ? (
+        <div className="error-div">
+          <FontAwesomeIcon
+            className="error-icon"
+            icon={faExclamationTriangle}
+          />
+          {errors}
+        </div>
+      ) : null}
 
       <style jsx>{`
+        div.definition-container {
+          display: flex;
+        }
+
         div:not(:last-child) {
-          margin-bottom: 1em;
+          margin-bottom: 0.5em;
         }
         div :global(.error-icon) {
           color: #cd2026;

--- a/app/lib/theme/ReadOnlyTheme.tsx
+++ b/app/lib/theme/ReadOnlyTheme.tsx
@@ -1,5 +1,5 @@
 import { ThemeProps } from "@rjsf/core";
-import FieldTemplate from "./FieldTemplate";
+import ReadOnlyFieldTemplate from "./ReadOnlyFieldTemplate";
 import ReadOnlyObjectFieldTemplate from "./ReadOnlyObjectFieldTemplate";
 import { utils } from "@rjsf/core";
 import ReadOnlyWidget from "./widgets/ReadOnlyWidget";
@@ -23,7 +23,7 @@ const readOnlyTheme: ThemeProps = {
     SelectProjectStatusWidget: ReadOnlyWidget,
   },
   ObjectFieldTemplate: ReadOnlyObjectFieldTemplate,
-  FieldTemplate: FieldTemplate,
+  FieldTemplate: ReadOnlyFieldTemplate,
 };
 
 export default readOnlyTheme;

--- a/app/lib/theme/utils/getRequiredLabel.ts
+++ b/app/lib/theme/utils/getRequiredLabel.ts
@@ -1,4 +1,0 @@
-const getRequiredLabel = (label: string, required: boolean) =>
-  label + (required ? "" : " (optional)");
-
-export default getRequiredLabel;

--- a/app/lib/theme/widgets/DisplayOnlyWidget.tsx
+++ b/app/lib/theme/widgets/DisplayOnlyWidget.tsx
@@ -1,12 +1,7 @@
 import { WidgetProps } from "@rjsf/core";
 
-const DisplayOnlyWidget: React.FC<WidgetProps> = ({ options }) => {
-  return (
-    <span className="paragraph-text">
-      <label>{options.title}</label>
-      <p>{options.text}</p>
-    </span>
-  );
+const DisplayOnlyWidget: React.FC<WidgetProps> = ({ options, id }) => {
+  return <span id={id}>{options.text}</span>;
 };
 
 export default DisplayOnlyWidget;

--- a/app/lib/theme/widgets/FieldLabel.tsx
+++ b/app/lib/theme/widgets/FieldLabel.tsx
@@ -1,32 +1,33 @@
-import { UiSchema } from "@rjsf/core";
-import getRequiredLabel from "../utils/getRequiredLabel";
-
 interface Props {
   label: string;
   required: boolean;
   htmlFor: string;
-  uiSchema?: UiSchema;
+  tagName?: "label" | "dt";
 }
 
 const FieldLabel: React.FC<Props> = ({
   label,
   required,
   htmlFor,
-  uiSchema,
+  tagName = "label",
 }) => {
-  if (
-    uiSchema &&
-    uiSchema["ui:options"] &&
-    uiSchema["ui:options"].label === false
-  ) {
+  if (!label) {
     return null;
   }
+
+  const displayedLabel = label + (required ? "" : " (optional)") + " ";
+
+  if (tagName === "label")
+    return <label htmlFor={htmlFor}>{displayedLabel}</label>;
+
   return (
     <>
-      <label htmlFor={htmlFor}>{getRequiredLabel(label, required)}</label>
-      {uiSchema && uiSchema["bcgov:help-text"] && (
-        <small>&nbsp;{uiSchema["bcgov:help-text"]}</small>
-      )}
+      <dt>{displayedLabel}</dt>
+      <style jsx>{`
+        dt {
+          margin-right: 1rem;
+        }
+      `}</style>
     </>
   );
 };

--- a/app/lib/theme/widgets/MoneyWidget.tsx
+++ b/app/lib/theme/widgets/MoneyWidget.tsx
@@ -1,25 +1,16 @@
 import { WidgetProps } from "@rjsf/core";
 import NumberFormat from "react-number-format";
-import FieldLabel from "./FieldLabel";
 
 export const MoneyWidget: React.FC<WidgetProps> = ({
   schema,
   id,
   disabled,
   label,
-  required,
   onChange,
   value,
-  uiSchema,
 }) => {
   return (
     <div>
-      <FieldLabel
-        label={label}
-        required={required}
-        htmlFor={id}
-        uiSchema={uiSchema}
-      />
       <NumberFormat
         thousandSeparator
         fixedDecimalScale

--- a/app/lib/theme/widgets/PhoneNumberWidget.tsx
+++ b/app/lib/theme/widgets/PhoneNumberWidget.tsx
@@ -1,25 +1,16 @@
 import { WidgetProps } from "@rjsf/core";
 import NumberFormat from "react-number-format";
-import FieldLabel from "./FieldLabel";
 
 const PhoneNumberWidget: React.FC<WidgetProps> = ({
   schema,
   id,
   disabled,
   label,
-  required,
   onChange,
   value,
-  uiSchema,
 }) => {
   return (
     <>
-      <FieldLabel
-        htmlFor={id}
-        label={label}
-        required={required}
-        uiSchema={uiSchema}
-      ></FieldLabel>
       <NumberFormat
         isNumericString
         allowEmptyFormatting

--- a/app/lib/theme/widgets/ReadOnlyMoneyWidget.tsx
+++ b/app/lib/theme/widgets/ReadOnlyMoneyWidget.tsx
@@ -1,27 +1,24 @@
 import { WidgetProps } from "@rjsf/core";
 import NumberFormat from "react-number-format";
 
-const ReadOnlyMoneyWidget: React.FC<WidgetProps> = ({ id, label, value }) => {
+const ReadOnlyMoneyWidget: React.FC<WidgetProps> = ({ id, value }) => {
   return (
-    <>
-      <dt>{label}</dt>
-      <dd>
-        {value ? (
-          <NumberFormat
-            thousandSeparator
-            fixedDecimalScale
-            id={id}
-            prefix="$"
-            className="money"
-            decimalScale={2}
-            value={value}
-            displayType="text"
-          />
-        ) : (
-          <em>Not added</em>
-        )}
-      </dd>
-    </>
+    <dd>
+      {value ? (
+        <NumberFormat
+          thousandSeparator
+          fixedDecimalScale
+          id={id}
+          prefix="$"
+          className="money"
+          decimalScale={2}
+          value={value}
+          displayType="text"
+        />
+      ) : (
+        <em>Not added</em>
+      )}
+    </dd>
   );
 };
 

--- a/app/lib/theme/widgets/ReadOnlyWidget.tsx
+++ b/app/lib/theme/widgets/ReadOnlyWidget.tsx
@@ -1,11 +1,14 @@
 import { WidgetProps } from "@rjsf/core";
-const ReadOnlyWidget: React.FC<WidgetProps> = ({ label, value, options }) => {
+const ReadOnlyWidget: React.FC<WidgetProps> = ({ value, options }) => {
   return (
     <>
-      {/* Some of the uiSchemas that use this widget have the label text in the label prop; others have it in options.title. Similarly, some uiSchemas have the value in the value prop; others in options.text. */}
-      <dt>{options.title ?? label}</dt>
-
       <dd>{options.text ?? value ?? <em>Not added</em>}</dd>
+      <style jsx>{`
+        dd {
+          line-height: 1.2;
+          margin: 0;
+        }
+      `}</style>
     </>
   );
 };

--- a/app/lib/theme/widgets/SearchDropdownWidget.tsx
+++ b/app/lib/theme/widgets/SearchDropdownWidget.tsx
@@ -3,20 +3,10 @@ import { WidgetProps } from "@rjsf/core";
 import Widgets from "@rjsf/core/dist/cjs/components/widgets";
 import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
-import FieldLabel from "./FieldLabel";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 const SearchDropdownWidget: React.FC<WidgetProps> = (props) => {
-  const {
-    id,
-    onChange,
-    schema,
-    placeholder,
-    readonly,
-    label,
-    required,
-    uiSchema,
-  } = props;
+  const { id, onChange, schema, placeholder, readonly } = props;
 
   const handleChange = (e: React.ChangeEvent<{}>, option: any) => {
     onChange(option?.value);
@@ -33,52 +23,44 @@ const SearchDropdownWidget: React.FC<WidgetProps> = (props) => {
   if (readonly) return <Widgets.SelectWidget {...props} />;
 
   return (
-    <>
-      <FieldLabel
-        label={label}
-        required={required}
-        htmlFor={id}
-        uiSchema={uiSchema}
-      />
-      <Autocomplete
-        disableClearable
-        id={id}
-        options={schema.anyOf}
-        defaultValue={getSelected()}
-        value={getSelected()}
-        onChange={handleChange}
-        isOptionEqualToValue={(option) =>
-          props.value ? option.value === props.value : true
-        }
-        getOptionLabel={(option) => (option ? option.title : "")}
-        sx={{
-          border: "2px solid #606060",
-          borderRadius: "0.25em",
-          marginTop: "0.2em",
-          "&.Mui-focused": {
-            outlineStyle: "solid",
-            outlineWidth: "4px",
-            outlineColor: "#3B99FC",
-            outlineOffset: "1px",
-          },
-        }}
-        popupIcon={<KeyboardArrowDownIcon style={{ color: "black" }} />}
-        renderInput={(params) => {
-          return (
-            <TextField
-              {...params}
-              placeholder={placeholder}
-              variant="standard"
-              InputProps={{ ...params.InputProps, disableUnderline: true }}
-              sx={{
-                padding: "5px",
-                background: "white",
-              }}
-            />
-          );
-        }}
-      />
-    </>
+    <Autocomplete
+      disableClearable
+      id={id}
+      options={schema.anyOf}
+      defaultValue={getSelected()}
+      value={getSelected()}
+      onChange={handleChange}
+      isOptionEqualToValue={(option) =>
+        props.value ? option.value === props.value : true
+      }
+      getOptionLabel={(option) => (option ? option.title : "")}
+      sx={{
+        border: "2px solid #606060",
+        borderRadius: "0.25em",
+        marginTop: "0.2em",
+        "&.Mui-focused": {
+          outlineStyle: "solid",
+          outlineWidth: "4px",
+          outlineColor: "#3B99FC",
+          outlineOffset: "1px",
+        },
+      }}
+      popupIcon={<KeyboardArrowDownIcon style={{ color: "black" }} />}
+      renderInput={(params) => {
+        return (
+          <TextField
+            {...params}
+            placeholder={placeholder}
+            variant="standard"
+            InputProps={{ ...params.InputProps, disableUnderline: true }}
+            sx={{
+              padding: "5px",
+              background: "white",
+            }}
+          />
+        );
+      }}
+    />
   );
 };
 

--- a/app/lib/theme/widgets/SelectWidget.tsx
+++ b/app/lib/theme/widgets/SelectWidget.tsx
@@ -1,6 +1,5 @@
 import { WidgetProps } from "@rjsf/core";
 import Dropdown from "@button-inc/bcgov-theme/Dropdown";
-import FieldLabel from "./FieldLabel";
 
 interface Option {
   type: string;
@@ -28,12 +27,6 @@ const SelectWidget: React.FunctionComponent<WidgetProps> = (props) => {
 
   return (
     <div>
-      <FieldLabel
-        htmlFor={id}
-        label={label}
-        required={required}
-        uiSchema={uiSchema}
-      ></FieldLabel>
       <Dropdown
         id={id}
         onChange={(e) => onChange(e.target.value || undefined)}

--- a/app/lib/theme/widgets/TextAreaWidget.tsx
+++ b/app/lib/theme/widgets/TextAreaWidget.tsx
@@ -1,6 +1,5 @@
 import { WidgetProps } from "@rjsf/core";
 import Textarea from "@button-inc/bcgov-theme/Textarea";
-import FieldLabel from "./FieldLabel";
 
 const TextAreaWidget: React.FC<WidgetProps> = ({
   id,
@@ -9,16 +8,9 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
   label,
   value,
   required,
-  uiSchema,
 }) => {
   return (
-    <>
-      <FieldLabel
-        htmlFor={id}
-        label={label}
-        required={required}
-        uiSchema={uiSchema}
-      ></FieldLabel>
+    <div>
       <Textarea
         id={id}
         onChange={(e) => onChange(e.target.value || undefined)}
@@ -31,13 +23,13 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
       />
       <style jsx>
         {`
-          :global(textarea) {
+          div :global(textarea) {
             width: 100%;
             min-height: 10rem;
           }
         `}
       </style>
-    </>
+    </div>
   );
 };
 

--- a/app/lib/theme/widgets/TextWidget.tsx
+++ b/app/lib/theme/widgets/TextWidget.tsx
@@ -1,8 +1,6 @@
 import { WidgetProps } from "@rjsf/core";
 import Input from "@button-inc/bcgov-theme/Input";
 
-import FieldLabel from "./FieldLabel";
-
 const TextWidget: React.FC<WidgetProps> = ({
   id,
   placeholder,
@@ -10,16 +8,9 @@ const TextWidget: React.FC<WidgetProps> = ({
   label,
   value,
   required,
-  uiSchema,
 }) => {
   return (
-    <>
-      <FieldLabel
-        htmlFor={id}
-        label={label}
-        required={required}
-        uiSchema={uiSchema}
-      ></FieldLabel>
+    <div>
       <Input
         id={id}
         onChange={(e) => onChange(e.target.value || undefined)}
@@ -31,12 +22,12 @@ const TextWidget: React.FC<WidgetProps> = ({
       />
       <style jsx>
         {`
-          :global(.pg-input, .pg-input input) {
+          div :global(.pg-input, .pg-input input) {
             width: 100%;
           }
         `}
       </style>
-    </>
+    </div>
   );
 };
 

--- a/app/tests/unit/components/Form/ProjectForm.test.tsx
+++ b/app/tests/unit/components/Form/ProjectForm.test.tsx
@@ -204,6 +204,8 @@ describe("The Project Form", () => {
                 fundingStreamRfpId: 1,
                 projectName: "test project name",
                 totalFundingRequest: 12345,
+                projectStatusId: 1,
+                operatorTradeName: "test trade name",
               },
             },
           };

--- a/app/tests/unit/components/Form/__snapshots__/FormBase.test.tsx.snap
+++ b/app/tests/unit/components/Form/__snapshots__/FormBase.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`The FormBase component renders a test schema with the default theme 1`]
     novalidate=""
   >
     <div
-      class="jsx-3883368021"
+      class="jsx-1751233656"
     >
       <div
         class="sc-jRQBWg cDwDrH pg-grid-container"
@@ -24,28 +24,32 @@ exports[`The FormBase component renders a test schema with the default theme 1`]
               class="jsx-4178779636"
             >
               <div
-                class="jsx-3883368021"
+                class="jsx-1751233656"
               >
                 <label
                   for="root_field"
                 >
-                  field
+                  field 
                 </label>
                 <div
-                  class="sc-crHmcD bKATQK pg-input"
+                  class="jsx-4128436805"
                 >
-                  <input
-                    aria-label="field"
-                    class="sc-bqiRlB hrAFNs pg-input-input"
-                    id="root_field"
-                    name="root_field-input"
-                    placeholder=""
-                    required=""
-                    value="test"
-                  />
+                  <div
+                    class="sc-crHmcD bKATQK pg-input"
+                  >
+                    <input
+                      aria-label="field"
+                      class="sc-bqiRlB hrAFNs pg-input-input"
+                      id="root_field"
+                      name="root_field-input"
+                      placeholder=""
+                      required=""
+                      value="test"
+                    />
+                  </div>
                 </div>
                 <div
-                  class="jsx-3883368021 error-div"
+                  class="jsx-1751233656 error-div"
                 />
               </div>
             </fieldset>
@@ -53,7 +57,7 @@ exports[`The FormBase component renders a test schema with the default theme 1`]
         </div>
       </div>
       <div
-        class="jsx-3883368021 error-div"
+        class="jsx-1751233656 error-div"
       />
     </div>
   </form>
@@ -67,26 +71,32 @@ exports[`The FormBase component renders a test schema with the readonly theme 1`
     novalidate=""
   >
     <div
-      class="jsx-3883368021"
+      class="jsx-141906859"
     >
-      <div>
-        <div
-          class="jsx-3883368021"
-        >
-          <dt>
-            field
-          </dt>
-          <dd>
-            test
-          </dd>
+      <div
+        class="jsx-141906859 definition-container"
+      >
+        <div>
           <div
-            class="jsx-3883368021 error-div"
-          />
+            class="jsx-141906859"
+          >
+            <div
+              class="jsx-141906859 definition-container"
+            >
+              <dt
+                class="jsx-156197991"
+              >
+                field 
+              </dt>
+              <dd
+                class="jsx-2629253024"
+              >
+                test
+              </dd>
+            </div>
+          </div>
         </div>
       </div>
-      <div
-        class="jsx-3883368021 error-div"
-      />
     </div>
   </form>
 </div>

--- a/app/tests/unit/lib/theme/widgets/__snapshots__/SearchDropdown.test.tsx.snap
+++ b/app/tests/unit/lib/theme/widgets/__snapshots__/SearchDropdown.test.tsx.snap
@@ -2,11 +2,6 @@
 
 exports[`The SearchDropdown Widget Matches the snapshot with a default value set 1`] = `
 <div>
-  <label
-    for="1"
-  >
-    Search (optional)
-  </label>
   <div
     aria-expanded="false"
     class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1nmd8s9-MuiAutocomplete-root"
@@ -65,11 +60,6 @@ exports[`The SearchDropdown Widget Matches the snapshot with a default value set
 
 exports[`The SearchDropdown Widget Matches the snapshot with no default value set 1`] = `
 <div>
-  <label
-    for="1"
-  >
-    Search (optional)
-  </label>
   <div
     aria-expanded="false"
     class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1nmd8s9-MuiAutocomplete-root"

--- a/app/tests/unit/lib/theme/widgets/__snapshots__/SelectWidget.test.tsx.snap
+++ b/app/tests/unit/lib/theme/widgets/__snapshots__/SelectWidget.test.tsx.snap
@@ -5,11 +5,6 @@ exports[`The SelectWidget Widget Matches the snapshot with a default value set 1
   <div
     class="jsx-9409829"
   >
-    <label
-      for="1"
-    >
-      Search (optional)
-    </label>
     <div
       class="sc-eCImPb dfYLVh pg-select"
     >
@@ -52,11 +47,6 @@ exports[`The SelectWidget Widget Matches the snapshot with no default value set 
   <div
     class="jsx-9409829"
   >
-    <label
-      for="1"
-    >
-      Search (optional)
-    </label>
     <div
       class="sc-eCImPb dfYLVh pg-select"
     >

--- a/app/tests/unit/lib/theme/widgets/__snapshots__/TextWidget.test.tsx.snap
+++ b/app/tests/unit/lib/theme/widgets/__snapshots__/TextWidget.test.tsx.snap
@@ -2,22 +2,21 @@
 
 exports[`The Text Widget Matches the snapshot with the value set 1`] = `
 <div>
-  <label
-    for="1"
-  >
-     (optional)
-  </label>
   <div
-    class="sc-hKwDye jvzxmJ pg-input"
+    class="jsx-4128436805"
   >
-    <input
-      aria-label=""
-      class="sc-jRQBWg AhBXp pg-input-input"
-      id="1"
-      name="1-input"
-      placeholder="test placeholder"
-      value="test"
-    />
+    <div
+      class="sc-hKwDye jvzxmJ pg-input"
+    >
+      <input
+        aria-label=""
+        class="sc-jRQBWg AhBXp pg-input-input"
+        id="1"
+        name="1-input"
+        placeholder="test placeholder"
+        value="test"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
@@ -303,7 +303,6 @@ describe("The Create Project page", () => {
                   node: {
                     rowId: 3,
                     legalName: "third operator legal name",
-                    tradeName: "third operator trade name",
                     bcRegistryId: "EF3456789",
                   },
                 },
@@ -329,7 +328,6 @@ describe("The Create Project page", () => {
 
     expect(screen.getByText(/test-summary/)).toBeInTheDocument();
     expect(screen.getByText(/third operator legal name/i)).toBeInTheDocument();
-    expect(screen.getByText(/third operator trade name/i)).toBeInTheDocument();
     expect(screen.getByText(/test-proj/i)).toBeInTheDocument();
     expect(screen.getByText(/proposal submitted/i)).toBeInTheDocument();
     expect(screen.getByText(/test-prop-reference/i)).toBeInTheDocument();


### PR DESCRIPTION
- render label in rjsf fields instead of widgets
- updated summary page to display `dt` and `dd` elements on the same row
- removed operator trade name from operator selection widget
- use rjsf's `ui:help` instead of a custom option