### PR TITLE
fix: pre-upgrade script doesn't need to terminate connections

### DIFF
--- a/chart/cas-cif/values-dev.yaml
+++ b/chart/cas-cif/values-dev.yaml
@@ -9,11 +9,6 @@ nginx-sidecar:
 db:
   preUpgradeCommand: |
     psql -v "ON_ERROR_STOP=1" <<EOF
-      select pg_terminate_backend(pid) from pg_stat_activity where
-      -- don't kill my own connection!
-      pid <> pg_backend_pid()
-      -- don't kill the connections to other databases
-      and datname = '$(PGDATABASE)';
       drop schema sqitch if exists cascade;
       drop schema cif if exists cascade;
       drop schema cif_private if exists cascade;

--- a/chart/cas-cif/values-test.yaml
+++ b/chart/cas-cif/values-test.yaml
@@ -8,11 +8,6 @@ nginx-sidecar:
 db:
   preUpgradeCommand: |
     psql -v "ON_ERROR_STOP=1" <<EOF
-      select pg_terminate_backend(pid) from pg_stat_activity where
-      -- don't kill my own connection!
-      pid <> pg_backend_pid()
-      -- don't kill the connections to other databases
-      and datname = '$(PGDATABASE)';
       drop schema sqitch if exists cascade;
       drop schema cif if exists cascade;
       drop schema cif_private if exists cascade;


### PR DESCRIPTION
We're not dropping the database anymore