### PR TITLE
Feat - Read-only forms

### DIFF
--- a/app/components/Form/ProjectContactForm.tsx
+++ b/app/components/Form/ProjectContactForm.tsx
@@ -327,7 +327,7 @@ const ProjectContactForm: React.FC<Props> = (props) => {
                     ObjectFieldTemplate={EmptyObjectFieldTemplate}
                   />
                 </Grid.Col>
-                {projectRevision.changeStatus != "committed" && (
+                {projectRevision.changeStatus !== "committed" && (
                   <Grid.Col span={4}>
                     <Button variant="secondary" size="small">
                       Show Details

--- a/app/components/Form/ProjectContactForm.tsx
+++ b/app/components/Form/ProjectContactForm.tsx
@@ -65,8 +65,11 @@ const ProjectContactForm: React.FC<Props> = (props) => {
       fragment ProjectContactForm_projectRevision on ProjectRevision {
         id
         rowId
-        projectContactFormChanges(first: 500)
-          @connection(key: "connection_projectContactFormChanges") {
+        changeStatus
+        projectContactFormChanges(
+          first: 500
+          filter: { operation: { notEqualTo: ARCHIVE } }
+        ) @connection(key: "connection_projectContactFormChanges") {
           __id
           edges {
             node {
@@ -324,18 +327,20 @@ const ProjectContactForm: React.FC<Props> = (props) => {
                     ObjectFieldTemplate={EmptyObjectFieldTemplate}
                   />
                 </Grid.Col>
-                <Grid.Col span={4}>
-                  <Button variant="secondary" size="small">
-                    Show Details
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="small"
-                    onClick={clearPrimaryContact}
-                  >
-                    Clear
-                  </Button>
-                </Grid.Col>
+                {projectRevision.changeStatus != "committed" && (
+                  <Grid.Col span={4}>
+                    <Button variant="secondary" size="small">
+                      Show Details
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      onClick={clearPrimaryContact}
+                    >
+                      Clear
+                    </Button>
+                  </Grid.Col>
+                )}
               </Grid.Row>
               <label>Secondary Contacts</label>
               {alternateContactForms.map((form) => {

--- a/app/components/Form/ProjectContactFormSummary.tsx
+++ b/app/components/Form/ProjectContactFormSummary.tsx
@@ -18,6 +18,7 @@ const ProjectContactFormSummary: React.FC<Props> = (props) => {
     graphql`
       fragment ProjectContactFormSummary_projectRevision on ProjectRevision {
         projectContactFormChanges(
+          first: 500
           filter: { operation: { notEqualTo: ARCHIVE } }
         ) {
           edges {

--- a/app/components/Form/ProjectManagerFormGroup.tsx
+++ b/app/components/Form/ProjectManagerFormGroup.tsx
@@ -268,7 +268,7 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
           />
         ))}
       </FormBorder>
-      {projectRevision.changeStatus != "committed" && (
+      {projectRevision.changeStatus !== "committed" && (
         <Button
           size="medium"
           variant="primary"

--- a/app/components/Form/ProjectManagerFormGroup.tsx
+++ b/app/components/Form/ProjectManagerFormGroup.tsx
@@ -33,6 +33,7 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
       fragment ProjectManagerFormGroup_revision on ProjectRevision {
         id
         rowId
+        changeStatus
         managerFormChanges: projectManagerFormChangesByLabel {
           edges {
             node {
@@ -266,15 +267,16 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
           />
         ))}
       </FormBorder>
-      <Button
-        size="medium"
-        variant="primary"
-        onClick={stageProjectManagersFormChanges}
-        disabled={isUpdating}
-      >
-        Submit Managers
-      </Button>
-
+      {projectRevision.changeStatus != "committed" && (
+        <Button
+          size="medium"
+          variant="primary"
+          onClick={stageProjectManagersFormChanges}
+          disabled={isUpdating}
+        >
+          Submit Managers
+        </Button>
+      )}
       <style jsx>{`
         div :global(button.pg-button) {
           margin-left: 0.4em;

--- a/app/components/Form/ProjectManagerFormGroup.tsx
+++ b/app/components/Form/ProjectManagerFormGroup.tsx
@@ -34,7 +34,8 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
         id
         rowId
         changeStatus
-        managerFormChanges: projectManagerFormChangesByLabel {
+        managerFormChanges: projectManagerFormChangesByLabel(first: 1000)
+          @connection(key: "ProjectManagerFormGroup_managerFormChanges") {
           edges {
             node {
               formChange {

--- a/app/components/Project/ProjectTableRow.tsx
+++ b/app/components/Project/ProjectTableRow.tsx
@@ -1,6 +1,6 @@
 import Button from "@button-inc/bcgov-theme/Button";
 import { useRouter } from "next/router";
-import { getProjectViewPageRoute } from "pageRoutes";
+import { getProjectRevisionOverviewFormPageRoute } from "pageRoutes";
 import { useFragment, graphql } from "react-relay";
 import { ProjectTableRow_project$key } from "__generated__/ProjectTableRow_project.graphql";
 import Money from "lib/helpers/Money";
@@ -11,13 +11,13 @@ interface Props {
 
 const ProjectTableRow: React.FC<Props> = ({ project }) => {
   const {
-    id,
     projectName,
     proposalReference,
     projectStatusByProjectStatusId: { name },
     totalFundingRequest,
     operatorByOperatorId: { tradeName },
     projectManagersByProjectId,
+    projectRevisionsByProjectId,
   } = useFragment(
     graphql`
       fragment ProjectTableRow_project on Project {
@@ -41,6 +41,15 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
             }
           }
         }
+        projectRevisionsByProjectId(
+          first: 1
+          orderBy: UPDATED_AT_DESC
+          filter: { changeStatus: { equalTo: "committed" } }
+        ) {
+          nodes {
+            id
+          }
+        }
       }
     `,
     project
@@ -49,7 +58,11 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
   const router = useRouter();
 
   const handleViewClick = () => {
-    router.push(getProjectViewPageRoute(id));
+    router.push(
+      getProjectRevisionOverviewFormPageRoute(
+        projectRevisionsByProjectId.nodes[0].id
+      )
+    );
   };
 
   return (

--- a/app/components/Project/ProjectTableRow.tsx
+++ b/app/components/Project/ProjectTableRow.tsx
@@ -17,7 +17,7 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
     totalFundingRequest,
     operatorByOperatorId: { tradeName },
     projectManagersByProjectId,
-    projectRevisionsByProjectId,
+    latestCommittedProjectRevision,
   } = useFragment(
     graphql`
       fragment ProjectTableRow_project on Project {
@@ -41,14 +41,8 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
             }
           }
         }
-        projectRevisionsByProjectId(
-          first: 1
-          orderBy: UPDATED_AT_DESC
-          filter: { changeStatus: { equalTo: "committed" } }
-        ) {
-          nodes {
-            id
-          }
+        latestCommittedProjectRevision {
+          id
         }
       }
     `,
@@ -59,9 +53,7 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
 
   const handleViewClick = () => {
     router.push(
-      getProjectRevisionOverviewFormPageRoute(
-        projectRevisionsByProjectId.nodes[0].id
-      )
+      getProjectRevisionOverviewFormPageRoute(latestCommittedProjectRevision.id)
     );
   };
 

--- a/app/components/TaskList.tsx
+++ b/app/components/TaskList.tsx
@@ -157,7 +157,9 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
                   <a>{mode === "update" ? "Edit" : "Add"} project overview</a>
                 )}
               </Link>
-              <div className="status">{projectOverviewStatus}</div>
+              {mode != "view" && (
+                <div className="status">{projectOverviewStatus}</div>
+              )}
             </li>
           </ul>
         </li>
@@ -175,7 +177,9 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
                   <a>{mode === "update" ? "Edit" : "Add"} project managers</a>
                 )}
               </Link>
-              <div className="status">{projectManagerStatus}</div>
+              {mode != "view" && (
+                <div className="status">{projectManagerStatus}</div>
+              )}
             </li>
             <li
               aria-current={currentStep === "contacts" ? "step" : false}
@@ -188,7 +192,9 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
                   <a>{mode === "update" ? "Edit" : "Add"} project contacts</a>
                 )}
               </Link>
-              <div className="status">{projectContactStatus}</div>
+              {mode != "view" && (
+                <div className="status">{projectContactStatus}</div>
+              )}
             </li>
           </ul>
         </li>

--- a/app/components/TaskList.tsx
+++ b/app/components/TaskList.tsx
@@ -133,6 +133,54 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
     return routeParts[routeParts.length - 1];
   }, [id, router]);
 
+  const getFormListItem = (stepName, linkUrl, formTitle, formStatus) => {
+    return (
+      <li
+        aria-current={currentStep === stepName ? "step" : false}
+        className="bordered"
+      >
+        <Link href={linkUrl}>
+          <a>
+            {mode === "view" || stepName === "summary"
+              ? formTitle
+              : `${
+                  mode === "update" ? "Edit" : "Add"
+                } ${formTitle.toLowerCase()}`}
+          </a>
+        </Link>
+        {mode !== "view" && <div className="status">{formStatus}</div>}
+
+        <style jsx>{`
+          li {
+            text-indent: 15px;
+            margin-bottom: 0;
+            display: flex;
+            justify-content: space-between;
+          }
+          li[aria-current="step"],
+          li[aria-current="step"] div {
+            background-color: #fafafc;
+          }
+
+          .bordered {
+            border-bottom: 1px solid #d1d1d1;
+            padding: 10px 0 10px 0;
+          }
+
+          ul > li {
+            display: flex;
+            justify-content: space-between;
+          }
+
+          .status {
+            text-align: right;
+            padding-right: 5px;
+          }
+        `}</style>
+      </li>
+    );
+  };
+
   return (
     <div className="container">
       <h2>
@@ -146,72 +194,41 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
         <li>
           <h3>1. Project Overview</h3>
           <ul>
-            <li
-              aria-current={currentStep === "overview" ? "step" : false}
-              className="bordered"
-            >
-              <Link href={getProjectRevisionOverviewFormPageRoute(id)}>
-                {mode === "view" ? (
-                  <a>Project overview</a>
-                ) : (
-                  <a>{mode === "update" ? "Edit" : "Add"} project overview</a>
-                )}
-              </Link>
-              {mode != "view" && (
-                <div className="status">{projectOverviewStatus}</div>
-              )}
-            </li>
+            {getFormListItem(
+              "overview",
+              getProjectRevisionOverviewFormPageRoute(id),
+              "Project overview",
+              projectOverviewStatus
+            )}
           </ul>
         </li>
         <li>
           <h3>2. Project Details {mode === "update" ? "" : "(optional)"}</h3>
           <ul>
-            <li
-              aria-current={currentStep === "managers" ? "step" : false}
-              className="bordered"
-            >
-              <Link href={getProjectRevisionManagersFormPageRoute(id)}>
-                {mode === "view" ? (
-                  <a>Project managers</a>
-                ) : (
-                  <a>{mode === "update" ? "Edit" : "Add"} project managers</a>
-                )}
-              </Link>
-              {mode != "view" && (
-                <div className="status">{projectManagerStatus}</div>
-              )}
-            </li>
-            <li
-              aria-current={currentStep === "contacts" ? "step" : false}
-              className="bordered"
-            >
-              <Link href={getProjectRevisionContactsFormPageRoute(id)}>
-                {mode === "view" ? (
-                  <a>Project contacts</a>
-                ) : (
-                  <a>{mode === "update" ? "Edit" : "Add"} project contacts</a>
-                )}
-              </Link>
-              {mode != "view" && (
-                <div className="status">{projectContactStatus}</div>
-              )}
-            </li>
+            {getFormListItem(
+              "managers",
+              getProjectRevisionManagersFormPageRoute(id),
+              "Project managers",
+              projectManagerStatus
+            )}
+            {getFormListItem(
+              "contacts",
+              getProjectRevisionContactsFormPageRoute(id),
+              "Project contacts",
+              projectContactStatus
+            )}
           </ul>
         </li>
-        {mode != "view" && (
+        {mode !== "view" && (
           <li>
             <h3>3. Submit changes</h3>
             <ul>
-              <li
-                aria-current={currentStep === "summary" ? "step" : false}
-                className="bordered"
-              >
-                <div>
-                  <Link href={getProjectRevisionPageRoute(id)}>
-                    Review and submit information
-                  </Link>
-                </div>
-              </li>
+              {getFormListItem(
+                "summary",
+                getProjectRevisionPageRoute(id),
+                "Review and submit information",
+                null
+              )}
             </ul>
           </li>
         )}
@@ -230,6 +247,11 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
         li {
           text-indent: 15px;
           margin-bottom: 0;
+        }
+
+        ul > li {
+          display: flex;
+          justify-content: space-between;
         }
 
         h2 {
@@ -257,29 +279,9 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
           color: blue;
         }
 
-        li[aria-current="step"],
-        li[aria-current="step"] div {
-          background-color: #fafafc;
-        }
-
-        .bordered {
-          border-bottom: 1px solid #d1d1d1;
-          padding: 10px 0 10px 0;
-        }
-
         div.container {
           background-color: #e5e5e5;
           width: 400px;
-        }
-
-        ul > li {
-          display: flex;
-          justify-content: space-between;
-        }
-
-        .status {
-          text-align: right;
-          padding-right: 5px;
         }
       `}</style>
     </div>

--- a/app/components/TaskList.tsx
+++ b/app/components/TaskList.tsx
@@ -53,10 +53,12 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
     projectFormChange,
     tasklistProjectContactFormChanges,
     projectManagerFormChanges,
+    changeStatus,
   } = useFragment(
     graphql`
       fragment TaskList_projectRevision on ProjectRevision {
         id
+        changeStatus
         projectByProjectId {
           proposalReference
         }
@@ -93,7 +95,12 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
   );
   const router = useRouter();
 
-  let mode = projectByProjectId ? "update" : "create";
+  let mode =
+    changeStatus === "committed"
+      ? "view"
+      : projectByProjectId
+      ? "update"
+      : "create";
 
   const projectOverviewStatus = useMemo(
     () => getStatus([projectFormChange]),
@@ -129,7 +136,9 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
   return (
     <div className="container">
       <h2>
-        {projectByProjectId
+        {mode === "view"
+          ? projectByProjectId.proposalReference
+          : mode === "update"
           ? "Editing: " + projectByProjectId.proposalReference
           : "Add a Project"}
       </h2>
@@ -142,7 +151,11 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
               className="bordered"
             >
               <Link href={getProjectRevisionOverviewFormPageRoute(id)}>
-                <a>{mode === "update" ? "Edit" : "Add"} project overview</a>
+                {mode === "view" ? (
+                  <a>Project overview</a>
+                ) : (
+                  <a>{mode === "update" ? "Edit" : "Add"} project overview</a>
+                )}
               </Link>
               <div className="status">{projectOverviewStatus}</div>
             </li>
@@ -156,7 +169,11 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
               className="bordered"
             >
               <Link href={getProjectRevisionManagersFormPageRoute(id)}>
-                <a>{mode === "update" ? "Edit" : "Add"} project managers</a>
+                {mode === "view" ? (
+                  <a>Project managers</a>
+                ) : (
+                  <a>{mode === "update" ? "Edit" : "Add"} project managers</a>
+                )}
               </Link>
               <div className="status">{projectManagerStatus}</div>
             </li>
@@ -165,27 +182,33 @@ const TaskList: React.FC<Props> = ({ projectRevision }) => {
               className="bordered"
             >
               <Link href={getProjectRevisionContactsFormPageRoute(id)}>
-                <a>{mode === "update" ? "Edit" : "Add"} project contacts</a>
+                {mode === "view" ? (
+                  <a>Project contacts</a>
+                ) : (
+                  <a>{mode === "update" ? "Edit" : "Add"} project contacts</a>
+                )}
               </Link>
               <div className="status">{projectContactStatus}</div>
             </li>
           </ul>
         </li>
-        <li>
-          <h3>3. Submit changes</h3>
-          <ul>
-            <li
-              aria-current={currentStep === "summary" ? "step" : false}
-              className="bordered"
-            >
-              <div>
-                <Link href={getProjectRevisionPageRoute(id)}>
-                  Review and submit information
-                </Link>
-              </div>
-            </li>
-          </ul>
-        </li>
+        {mode != "view" && (
+          <li>
+            <h3>3. Submit changes</h3>
+            <ul>
+              <li
+                aria-current={currentStep === "summary" ? "step" : false}
+                className="bordered"
+              >
+                <div>
+                  <Link href={getProjectRevisionPageRoute(id)}>
+                    Review and submit information
+                  </Link>
+                </div>
+              </li>
+            </ul>
+          </li>
+        )}
       </ol>
       <style jsx>{`
         ol {

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -220,11 +220,39 @@ describe("the new project page", () => {
     cy.url().should("include", "/cif/projects");
     cy.findByText("View").click();
     cy.url().should("include", "/form/overview");
-    cy.useMockedTime(new Date("June 10, 2020 09:00:01"));
-    cy.findByText("Edit").click();
+
+    // Verify the forms render in view mode for committed project revisions
+    cy.findByRole("heading", { name: "3. Submit changes" }).should("not.exist");
+    cy.findByRole("link", { name: "Project overview" })
+      .next()
+      .should("not.exist");
+    cy.findByRole("button", { name: /submit/i }).should("not.exist");
+    cy.findByText(/Funding Stream RFP ID/i)
+      .next()
+      .should("have.text", "Emissions Performance - 2020");
+    cy.findByRole("link", { name: "Project managers" })
+      .next()
+      .should("not.exist");
+    cy.findByRole("link", { name: "Project managers" }).click();
+    cy.url().should("include", "/form/managers");
+    cy.findByRole("button", { name: /submit/i }).should("not.exist");
+    cy.findByText("Tech Team Primary (optional)")
+      .next()
+      .should("have.text", "Swanson, Ron");
+    cy.findByRole("link", { name: "Project contacts" })
+      .next()
+      .should("not.exist");
+    cy.findByRole("link", { name: "Project contacts" }).click();
+    cy.url().should("include", "/form/contacts");
+    cy.findByRole("button", { name: /submit/i }).should("not.exist");
+    cy.findByText(/primary contact/i, "Loblaw003, Bob003");
 
     // Edit the project
     // change the name, delete a manager and contact.
+    cy.findByRole("link", { name: "Project overview" }).click();
+    cy.useMockedTime(new Date("June 10, 2020 09:00:01"));
+    cy.findByText("Edit").click();
+
     cy.findByLabelText(/Project Name/i)
       .should("have.value", "Foo")
       .clear()

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -219,10 +219,9 @@ describe("the new project page", () => {
     cy.findByRole("button", { name: /submit/i }).click();
     cy.url().should("include", "/cif/projects");
     cy.findByText("View").click();
-    cy.url().should("include", "/cif/project/");
+    cy.url().should("include", "/form/overview");
     cy.useMockedTime(new Date("June 10, 2020 09:00:01"));
     cy.findByText("Edit").click();
-    cy.url().should("include", "/form/overview");
 
     // Edit the project
     // change the name, delete a manager and contact.
@@ -296,16 +295,18 @@ describe("the new project page", () => {
 
     cy.url().should("include", "/cif/projects");
     cy.findByRole("button", { name: /view/i }).click();
-    cy.url().should("include", "/cif/project/");
-    cy.findByRole("button", { name: /edit/i }).click();
     cy.url().should("include", "/form/overview");
 
     // Check the project was updated
-    cy.findByLabelText(/Project Name/i).should("have.value", "Bar");
-    cy.findByText(/Edit project managers/i).click();
-    cy.findByLabelText(/tech team secondary/i).should("not.have.value");
-    cy.findByText(/Edit project contacts/i).click();
-    cy.get("fieldset").find("input").should("have.length", 1);
+    cy.findByText(/Project Name/i)
+      .next()
+      .should("have.text", "Bar");
+    cy.findByText(/Project managers/i).click();
+    cy.findByText(/tech team secondary/i).should("not.exist");
+    cy.findByText(/Project contacts/i).click();
+    cy.findByText(/Secondary contacts/i)
+      .next()
+      .should("have.text", "Not added");
   });
 
   it("undoes changes on an existing project when the user clicks the Undo Changes button", () => {

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -209,7 +209,7 @@ describe("the new project page", () => {
     cy.contains(/Primary contact/i)
       .next()
       .should("have.text", "Loblaw003, Bob003");
-    cy.findByText(/Secondary contacts/i)
+    cy.findByText(/^Secondary contacts/i)
       .next()
       .should("have.text", "Loblaw004, Bob004");
     cy.get("body").happoScreenshot({
@@ -303,7 +303,7 @@ describe("the new project page", () => {
       .should("have.text", "Bar");
     cy.findByText(/tech team secondary/i).should("not.exist");
 
-    cy.findByText(/Secondary Contacts/i)
+    cy.findByText(/^Secondary Contacts/i)
       .next()
       .should("have.text", "No secondary contacts");
 
@@ -332,9 +332,9 @@ describe("the new project page", () => {
     cy.findByText(/Project managers/i).click();
     cy.findByText(/tech team secondary/i).should("not.exist");
     cy.findByText(/Project contacts/i).click();
-    cy.findByText(/Secondary contacts/i)
+    cy.findByText(/^Secondary contacts/i)
       .next()
-      .should("have.text", "Not added");
+      .should("have.text", "No secondary contacts");
   });
 
   it("undoes changes on an existing project when the user clicks the Undo Changes button", () => {

--- a/app/hooks/useRedirectToLatestRevision.ts
+++ b/app/hooks/useRedirectToLatestRevision.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+/**
+ *  Hook that returns true if the project revision being viewed is not the latest project revision, and shouldRedirect is true.
+ * False otherwise.
+ */
+export default function useRedirectToLatestRevision(
+  currentRevisionId,
+  latestRevisionId,
+  shouldRedirect
+) {
+  const router = useRouter();
+  useEffect(() => {
+    if (currentRevisionId != latestRevisionId && shouldRedirect)
+      router.replace(
+        `${router.pathname.replace("[projectRevision]", latestRevisionId)}`
+      );
+  }, [currentRevisionId, latestRevisionId, shouldRedirect, router]);
+  if (currentRevisionId != latestRevisionId && shouldRedirect) {
+    return true;
+  }
+  return false;
+}

--- a/app/hooks/useRedirectToLatestRevision.ts
+++ b/app/hooks/useRedirectToLatestRevision.ts
@@ -5,29 +5,18 @@ import { useRouter } from "next/router";
  * False otherwise.
  */
 export default function useRedirectToLatestRevision(
-  projectRevision,
+  currentRevisionId,
+  latestRevisionId,
   shouldRedirect
 ) {
   const router = useRouter();
   useEffect(() => {
-    if (
-      projectRevision?.id !=
-        projectRevision?.projectByProjectId?.latestCommittedProjectRevision
-          ?.id &&
-      shouldRedirect
-    )
+    if (currentRevisionId != latestRevisionId && shouldRedirect)
       router.replace(
-        `${router.pathname.replace(
-          "[projectRevision]",
-          projectRevision.projectByProjectId.latestCommittedProjectRevision.id
-        )}`
+        `${router.pathname.replace("[projectRevision]", latestRevisionId)}`
       );
-  }, [projectRevision, shouldRedirect, router]);
-  if (
-    projectRevision?.id !=
-      projectRevision?.projectByProjectId?.latestCommittedProjectRevision?.id &&
-    shouldRedirect
-  ) {
+  }, [currentRevisionId, latestRevisionId, shouldRedirect, router]);
+  if (currentRevisionId != latestRevisionId && shouldRedirect) {
     return true;
   }
   return false;

--- a/app/hooks/useRedirectToLatestRevision.ts
+++ b/app/hooks/useRedirectToLatestRevision.ts
@@ -11,7 +11,7 @@ export default function useRedirectToLatestRevision(
   const router = useRouter();
   useEffect(() => {
     if (
-      projectRevision.id !=
+      projectRevision?.id !=
         projectRevision?.projectByProjectId?.latestCommittedProjectRevision
           ?.id &&
       shouldRedirect
@@ -24,7 +24,7 @@ export default function useRedirectToLatestRevision(
       );
   }, [projectRevision, shouldRedirect, router]);
   if (
-    projectRevision.id !=
+    projectRevision?.id !=
       projectRevision?.projectByProjectId?.latestCommittedProjectRevision?.id &&
     shouldRedirect
   ) {

--- a/app/hooks/useRedirectToLatestRevision.ts
+++ b/app/hooks/useRedirectToLatestRevision.ts
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 /**
- *  Hook that returns true if the project revision being viewed is not the latest project revision, and shouldRedirect is true.
- * False otherwise.
+ *  Hook that returns true if the project revision being viewed is not the latest project revision,
+ *  the latest project revision id is not null, and shouldRedirect is true.
+ *  False otherwise.
  */
 export default function useRedirectToLatestRevision(
   currentRevisionId,
@@ -11,12 +12,20 @@ export default function useRedirectToLatestRevision(
 ) {
   const router = useRouter();
   useEffect(() => {
-    if (currentRevisionId != latestRevisionId && shouldRedirect)
+    if (
+      latestRevisionId &&
+      currentRevisionId !== latestRevisionId &&
+      shouldRedirect
+    )
       router.replace(
         `${router.pathname.replace("[projectRevision]", latestRevisionId)}`
       );
   }, [currentRevisionId, latestRevisionId, shouldRedirect, router]);
-  if (currentRevisionId != latestRevisionId && shouldRedirect) {
+  if (
+    latestRevisionId &&
+    currentRevisionId !== latestRevisionId &&
+    shouldRedirect
+  ) {
     return true;
   }
   return false;

--- a/app/hooks/useRedirectToLatestRevision.ts
+++ b/app/hooks/useRedirectToLatestRevision.ts
@@ -5,18 +5,29 @@ import { useRouter } from "next/router";
  * False otherwise.
  */
 export default function useRedirectToLatestRevision(
-  currentRevisionId,
-  latestRevisionId,
+  projectRevision,
   shouldRedirect
 ) {
   const router = useRouter();
   useEffect(() => {
-    if (currentRevisionId != latestRevisionId && shouldRedirect)
+    if (
+      projectRevision.id !=
+        projectRevision?.projectByProjectId?.latestCommittedProjectRevision
+          ?.id &&
+      shouldRedirect
+    )
       router.replace(
-        `${router.pathname.replace("[projectRevision]", latestRevisionId)}`
+        `${router.pathname.replace(
+          "[projectRevision]",
+          projectRevision.projectByProjectId.latestCommittedProjectRevision.id
+        )}`
       );
-  }, [currentRevisionId, latestRevisionId, shouldRedirect, router]);
-  if (currentRevisionId != latestRevisionId && shouldRedirect) {
+  }, [projectRevision, shouldRedirect, router]);
+  if (
+    projectRevision.id !=
+      projectRevision?.projectByProjectId?.latestCommittedProjectRevision?.id &&
+    shouldRedirect
+  ) {
     return true;
   }
   return false;

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -59,8 +59,7 @@ export function ProjectContactsPage({
     useCreateProjectRevision();
 
   const isRedirectingToLatestRevision = useRedirectToLatestRevision(
-    query.projectRevision?.id,
-    query.projectRevision?.projectByProjectId.latestCommittedProjectRevision.id,
+    query.projectRevision,
     mode === "view"
   );
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -115,7 +115,6 @@ export function ProjectContactsPage({
   const handleSubmit = () => {
     router.push(getProjectRevisionPageRoute(query.projectRevision.id));
   };
-  console.log(mode);
   return (
     <DefaultLayout session={query.session} leftSideNav={taskList}>
       {mode === "view" ? (

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -12,6 +12,7 @@ import { useCreateProjectRevision } from "mutations/ProjectRevision/createProjec
 import ProjectContactForm from "components/Form/ProjectContactForm";
 import TaskList from "components/TaskList";
 import useRedirectTo404IfFalsy from "hooks/useRedirectTo404IfFalsy";
+import useRedirectToLatestRevision from "hooks/useRedirectToLatestRevision";
 import ProjectContactFormSummary from "components/Form/ProjectContactFormSummary";
 import { Button } from "@button-inc/bcgov-theme";
 
@@ -27,6 +28,9 @@ const pageQuery = graphql`
         projectId
         projectByProjectId {
           pendingProjectRevision {
+            id
+          }
+          latestCommittedProjectRevision {
             id
           }
         }
@@ -54,8 +58,13 @@ export function ProjectContactsPage({
   const [createProjectRevision, isCreatingProjectRevision] =
     useCreateProjectRevision();
 
+  const isRedirectingToLatestRevision = useRedirectToLatestRevision(
+    query.projectRevision?.id,
+    query.projectRevision?.projectByProjectId.latestCommittedProjectRevision.id,
+    mode === "view"
+  );
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);
-  if (isRedirecting) return null;
+  if (isRedirecting || isRedirectingToLatestRevision) return null;
 
   const handleCreateRevision = () => {
     createProjectRevision({

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -45,7 +45,7 @@ export function ProjectContactsPage({
 }: RelayProps<{}, contactsFormQuery>) {
   const { query } = usePreloadedQuery(pageQuery, preloadedQuery);
   const router = useRouter();
-  const mode = !query.projectRevision.projectId
+  const mode = !query.projectRevision?.projectId
     ? "create"
     : query.projectRevision.changeStatus === "committed"
     ? "view"

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -26,15 +26,8 @@ const pageQuery = graphql`
         changeStatus
         projectId
         projectByProjectId {
-          projectRevisionsByProjectId(
-            first: 1
-            filter: { changeStatus: { equalTo: "pending" } }
-            orderBy: UPDATED_AT_DESC
-          ) {
-            nodes {
-              id
-              changeStatus
-            }
+          pendingProjectRevision {
+            id
           }
         }
         ...ProjectContactForm_projectRevision
@@ -80,16 +73,14 @@ export function ProjectContactsPage({
   const handleResumeRevision = () => {
     router.push(
       getProjectRevisionContactsFormPageRoute(
-        query.projectRevision.projectByProjectId.projectRevisionsByProjectId
-          .nodes[0].id
+        query.projectRevision.projectByProjectId.pendingProjectRevision.id
       )
     );
   };
 
   const createEditButton = () => {
     const existingRevision =
-      query.projectRevision.projectByProjectId.projectRevisionsByProjectId
-        .nodes[0];
+      query.projectRevision.projectByProjectId.pendingProjectRevision;
     return (
       <>
         <Button

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -92,7 +92,7 @@ export function ProjectContactsPage({
     const existingRevision =
       query.projectRevision.projectByProjectId.pendingProjectRevision;
     return (
-      <>
+      <div>
         <Button
           className="edit-button"
           onClick={
@@ -103,11 +103,11 @@ export function ProjectContactsPage({
           {existingRevision ? "Resume Edition" : "Edit"}
         </Button>
         <style jsx>{`
-          :global(.edit-button) {
+          div :global(.edit-button) {
             float: right;
           }
         `}</style>
-      </>
+      </div>
     );
   };
 

--- a/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/contacts.tsx
@@ -59,7 +59,9 @@ export function ProjectContactsPage({
     useCreateProjectRevision();
 
   const isRedirectingToLatestRevision = useRedirectToLatestRevision(
-    query.projectRevision,
+    query.projectRevision?.id,
+    query.projectRevision?.projectByProjectId?.latestCommittedProjectRevision
+      ?.id,
     mode === "view"
   );
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);

--- a/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
@@ -98,8 +98,7 @@ export function ProjectManagersForm({
   };
 
   const isRedirectingToLatestRevision = useRedirectToLatestRevision(
-    query.projectRevision?.id,
-    query.projectRevision?.projectByProjectId.latestCommittedProjectRevision.id,
+    query.projectRevision,
     query.projectRevision?.changeStatus === "committed"
   );
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);

--- a/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
@@ -98,7 +98,9 @@ export function ProjectManagersForm({
   };
 
   const isRedirectingToLatestRevision = useRedirectToLatestRevision(
-    query.projectRevision,
+    query.projectRevision?.id,
+    query.projectRevision?.projectByProjectId?.latestCommittedProjectRevision
+      ?.id,
     query.projectRevision?.changeStatus === "committed"
   );
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);

--- a/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
@@ -12,6 +12,7 @@ import {
 } from "pageRoutes";
 import { useCreateProjectRevision } from "mutations/ProjectRevision/createProjectRevision";
 import useRedirectTo404IfFalsy from "hooks/useRedirectTo404IfFalsy";
+import useRedirectToLatestRevision from "hooks/useRedirectToLatestRevision";
 import { useRouter } from "next/router";
 import { Button } from "@button-inc/bcgov-theme";
 
@@ -27,6 +28,9 @@ const pageQuery = graphql`
         projectId
         projectByProjectId {
           pendingProjectRevision {
+            id
+          }
+          latestCommittedProjectRevision {
             id
           }
         }
@@ -93,8 +97,13 @@ export function ProjectManagersForm({
     );
   };
 
+  const isRedirectingToLatestRevision = useRedirectToLatestRevision(
+    query.projectRevision?.id,
+    query.projectRevision?.projectByProjectId.latestCommittedProjectRevision.id,
+    query.projectRevision?.changeStatus === "committed"
+  );
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);
-  if (isRedirecting) return null;
+  if (isRedirecting || isRedirectingToLatestRevision) return null;
 
   const taskList = <TaskList projectRevision={query.projectRevision} />;
 

--- a/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
@@ -78,7 +78,7 @@ export function ProjectManagersForm({
     const existingRevision =
       query.projectRevision.projectByProjectId.pendingProjectRevision;
     return (
-      <>
+      <div>
         <Button
           className="edit-button"
           onClick={
@@ -89,11 +89,11 @@ export function ProjectManagersForm({
           {existingRevision ? "Resume Edition" : "Edit"}
         </Button>
         <style jsx>{`
-          :global(.edit-button) {
+          div :global(.edit-button) {
             float: right;
           }
         `}</style>
-      </>
+      </div>
     );
   };
 

--- a/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
@@ -4,6 +4,7 @@ import { graphql, usePreloadedQuery } from "react-relay/hooks";
 import { managersFormQuery } from "__generated__/managersFormQuery.graphql";
 import withRelayOptions from "lib/relay/withRelayOptions";
 import ProjectManagerFormGroup from "components/Form/ProjectManagerFormGroup";
+import ProjectManagerFormSummary from "components/Form/ProjectManagerFormSummary";
 import TaskList from "components/TaskList";
 import { getProjectRevisionPageRoute } from "pageRoutes";
 import useRedirectTo404IfFalsy from "hooks/useRedirectTo404IfFalsy";
@@ -17,10 +18,13 @@ const pageQuery = graphql`
       }
       projectRevision(id: $projectRevision) {
         id
+        changeStatus
         ...ProjectManagerFormGroup_revision
+        ...ProjectManagerFormSummary_projectRevision
         ...TaskList_projectRevision
       }
       ...ProjectManagerFormGroup_query
+      ...ProjectManagerFormSummary_query
     }
   }
 `;
@@ -42,11 +46,18 @@ export function ProjectManagersForm({
 
   return (
     <DefaultLayout session={query.session} leftSideNav={taskList}>
-      <ProjectManagerFormGroup
-        query={query}
-        revision={query.projectRevision}
-        onSubmit={handleSubmit}
-      />
+      {query.projectRevision.changeStatus === "committed" ? (
+        <ProjectManagerFormSummary
+          query={query}
+          projectRevision={query.projectRevision}
+        />
+      ) : (
+        <ProjectManagerFormGroup
+          query={query}
+          revision={query.projectRevision}
+          onSubmit={handleSubmit}
+        />
+      )}
     </DefaultLayout>
   );
 }

--- a/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/managers.tsx
@@ -26,15 +26,8 @@ const pageQuery = graphql`
         changeStatus
         projectId
         projectByProjectId {
-          projectRevisionsByProjectId(
-            first: 1
-            filter: { changeStatus: { equalTo: "pending" } }
-            orderBy: UPDATED_AT_DESC
-          ) {
-            nodes {
-              id
-              changeStatus
-            }
+          pendingProjectRevision {
+            id
           }
         }
         ...ProjectManagerFormGroup_revision
@@ -72,16 +65,14 @@ export function ProjectManagersForm({
   const handleResumeRevision = () => {
     router.push(
       getProjectRevisionManagersFormPageRoute(
-        query.projectRevision.projectByProjectId.projectRevisionsByProjectId
-          .nodes[0].id
+        query.projectRevision.projectByProjectId.pendingProjectRevision.id
       )
     );
   };
 
   const createEditButton = () => {
     const existingRevision =
-      query.projectRevision.projectByProjectId.projectRevisionsByProjectId
-        .nodes[0];
+      query.projectRevision.projectByProjectId.pendingProjectRevision;
     return (
       <>
         <Button

--- a/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
@@ -58,7 +58,9 @@ export function ProjectOverviewForm({
 
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);
   const isRedirectingToLatestRevision = useRedirectToLatestRevision(
-    query.projectRevision,
+    query.projectRevision?.id,
+    query.projectRevision?.projectByProjectId?.latestCommittedProjectRevision
+      ?.id,
     mode === "view"
   );
   if (isRedirecting || isRedirectingToLatestRevision) return null;

--- a/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
@@ -26,15 +26,8 @@ const pageQuery = graphql`
         changeStatus
         projectId
         projectByProjectId {
-          projectRevisionsByProjectId(
-            first: 1
-            filter: { changeStatus: { equalTo: "pending" } }
-            orderBy: UPDATED_AT_DESC
-          ) {
-            nodes {
-              id
-              changeStatus
-            }
+          pendingProjectRevision {
+            id
           }
         }
         ...ProjectForm_projectRevision
@@ -74,16 +67,14 @@ export function ProjectOverviewForm({
   const handleResumeRevision = () => {
     router.push(
       getProjectRevisionOverviewFormPageRoute(
-        query.projectRevision.projectByProjectId.projectRevisionsByProjectId
-          .nodes[0].id
+        query.projectRevision.projectByProjectId.pendingProjectRevision.id
       )
     );
   };
 
   const createEditButton = () => {
     const existingRevision =
-      query.projectRevision.projectByProjectId.projectRevisionsByProjectId
-        .nodes[0];
+      query.projectRevision.projectByProjectId.pendingProjectRevision;
     return (
       <>
         <Button

--- a/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
@@ -13,6 +13,7 @@ import {
 } from "pageRoutes";
 import ProjectFormSummary from "components/Form/ProjectFormSummary";
 import { useCreateProjectRevision } from "mutations/ProjectRevision/createProjectRevision";
+import useRedirectToLatestRevision from "hooks/useRedirectToLatestRevision";
 import { Button } from "@button-inc/bcgov-theme";
 
 const pageQuery = graphql`
@@ -27,6 +28,9 @@ const pageQuery = graphql`
         projectId
         projectByProjectId {
           pendingProjectRevision {
+            id
+          }
+          latestCommittedProjectRevision {
             id
           }
         }
@@ -46,11 +50,19 @@ export function ProjectOverviewForm({
   const { query } = usePreloadedQuery(pageQuery, preloadedQuery);
   const router = useRouter();
 
+  const mode =
+    query.projectRevision?.changeStatus === "committed" ? "view" : "update";
+
   const [createProjectRevision, isCreatingProjectRevision] =
     useCreateProjectRevision();
 
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);
-  if (isRedirecting) return null;
+  const isRedirectingToLatestRevision = useRedirectToLatestRevision(
+    query.projectRevision?.id,
+    query.projectRevision?.projectByProjectId.latestCommittedProjectRevision.id,
+    mode === "view"
+  );
+  if (isRedirecting || isRedirectingToLatestRevision) return null;
 
   const handleCreateRevision = () => {
     createProjectRevision({

--- a/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
@@ -58,8 +58,7 @@ export function ProjectOverviewForm({
 
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);
   const isRedirectingToLatestRevision = useRedirectToLatestRevision(
-    query.projectRevision?.id,
-    query.projectRevision?.projectByProjectId.latestCommittedProjectRevision.id,
+    query.projectRevision,
     mode === "view"
   );
   if (isRedirecting || isRedirectingToLatestRevision) return null;

--- a/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
@@ -89,7 +89,7 @@ export function ProjectOverviewForm({
     const existingRevision =
       query.projectRevision.projectByProjectId.pendingProjectRevision;
     return (
-      <>
+      <div>
         <Button
           className="edit-button"
           onClick={
@@ -100,11 +100,11 @@ export function ProjectOverviewForm({
           {existingRevision ? "Resume Edition" : "Edit"}
         </Button>
         <style jsx>{`
-          :global(.edit-button) {
+          div :global(.edit-button) {
             float: right;
           }
         `}</style>
-      </>
+      </div>
     );
   };
 

--- a/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/overview.tsx
@@ -8,6 +8,7 @@ import TaskList from "components/TaskList";
 import useRedirectTo404IfFalsy from "hooks/useRedirectTo404IfFalsy";
 import { useRouter } from "next/router";
 import { getProjectRevisionPageRoute } from "pageRoutes";
+import ProjectFormSummary from "components/Form/ProjectFormSummary";
 
 const pageQuery = graphql`
   query overviewFormQuery($projectRevision: ID!) {
@@ -17,10 +18,13 @@ const pageQuery = graphql`
       }
       projectRevision(id: $projectRevision) {
         id
+        changeStatus
         ...ProjectForm_projectRevision
         ...TaskList_projectRevision
+        ...ProjectFormSummary_projectRevision
       }
       ...ProjectForm_query
+      ...ProjectFormSummary_query
     }
   }
 `;
@@ -42,11 +46,19 @@ export function ProjectOverviewForm({
 
   return (
     <DefaultLayout session={query.session} leftSideNav={taskList}>
-      <ProjectForm
-        query={query}
-        projectRevision={query.projectRevision}
-        onSubmit={handleSubmit}
-      />
+      {query.projectRevision.changeStatus === "committed" ? (
+        <ProjectFormSummary
+          query={query}
+          projectRevision={query.projectRevision}
+        />
+      ) : (
+        <ProjectForm
+          query={query}
+          projectRevision={query.projectRevision}
+          onSubmit={handleSubmit}
+          disabled={query.projectRevision.changeStatus === "committed"}
+        />
+      )}
     </DefaultLayout>
   );
 }

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -28,6 +28,7 @@ const pageQuery = graphql`
       projectRevision(id: $projectRevision) {
         id
         changeReason
+        changeStatus
         projectId
         ...ProjectFormSummary_projectRevision
         ...ProjectContactFormSummary_projectRevision
@@ -163,40 +164,52 @@ export function ProjectRevision({
 
         {query.projectRevision.projectId && (
           <div>
-            <h4>Please describe the reason for these changes</h4>
-            <SavingIndicator isSaved={!updatingChangeReason} />
-            <Textarea
-              value={query.projectRevision.changeReason}
-              onChange={handleChange}
-              size={"medium"}
-              resize="vertical"
-            />
+            {query.projectRevision.changeStatus === "committed" ? (
+              <>
+                <h4>Reason for change</h4>
+                <p>{query.projectRevision.changeReason}</p>
+              </>
+            ) : (
+              <>
+                <h4>Please describe the reason for these changes</h4>
+                <SavingIndicator isSaved={!updatingChangeReason} />
+                <Textarea
+                  value={query.projectRevision.changeReason}
+                  onChange={handleChange}
+                  size={"medium"}
+                  resize="vertical"
+                />
+              </>
+            )}
           </div>
         )}
-
-        <Button
-          size="medium"
-          variant="primary"
-          onClick={commitProject}
-          disabled={
-            hasValidationErrors ||
-            updatingProjectRevision ||
-            discardingProjectRevision ||
-            updatingChangeReason ||
-            (query.projectRevision.projectId &&
-              !query.projectRevision.changeReason)
-          }
-        >
-          Submit
-        </Button>
-        <Button
-          size="medium"
-          variant="secondary"
-          onClick={discardRevision}
-          disabled={updatingProjectRevision || discardingProjectRevision}
-        >
-          Discard Changes
-        </Button>
+        {query.projectRevision.changeStatus != "committed" && (
+          <>
+            <Button
+              size="medium"
+              variant="primary"
+              onClick={commitProject}
+              disabled={
+                hasValidationErrors ||
+                updatingProjectRevision ||
+                discardingProjectRevision ||
+                updatingChangeReason ||
+                (query.projectRevision.projectId &&
+                  !query.projectRevision.changeReason)
+              }
+            >
+              Submit
+            </Button>
+            <Button
+              size="medium"
+              variant="secondary"
+              onClick={discardRevision}
+              disabled={updatingProjectRevision || discardingProjectRevision}
+            >
+              Discard Changes
+            </Button>
+          </>
+        )}
       </div>
       <style jsx>{`
         div :global(.pg-button) {
@@ -208,6 +221,9 @@ export function ProjectRevision({
         }
         div :global(.pg-textarea) {
           padding-top: 2px;
+        }
+        h4 {
+          margin-bottom: 0;
         }
       `}</style>
     </DefaultLayout>

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -7,13 +7,17 @@ import { graphql, usePreloadedQuery } from "react-relay/hooks";
 import { ProjectRevisionQuery } from "__generated__/ProjectRevisionQuery.graphql";
 import withRelayOptions from "lib/relay/withRelayOptions";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { Button, Textarea } from "@button-inc/bcgov-theme";
 import { mutation as updateProjectRevisionMutation } from "mutations/ProjectRevision/updateProjectRevision";
 import { useUpdateChangeReason } from "mutations/ProjectRevision/updateChangeReason";
 import { useDeleteProjectRevisionMutation } from "mutations/ProjectRevision/deleteProjectRevision";
 import SavingIndicator from "components/Form/SavingIndicator";
 
-import { getProjectsPageRoute } from "pageRoutes";
+import {
+  getProjectsPageRoute,
+  getProjectRevisionOverviewFormPageRoute,
+} from "pageRoutes";
 import useRedirectTo404IfFalsy from "hooks/useRedirectTo404IfFalsy";
 import TaskList from "components/TaskList";
 import useMutationWithErrorMessage from "mutations/useMutationWithErrorMessage";
@@ -73,8 +77,17 @@ export function ProjectRevision({
       ),
     [query.projectRevision?.formChangesByProjectRevisionId.edges]
   );
+  const isCommittedRevision =
+    query.projectRevision.changeStatus === "committed";
+  useEffect(() => {
+    if (isCommittedRevision)
+      router.push(
+        getProjectRevisionOverviewFormPageRoute(query.projectRevision.id)
+      );
+  }, [isCommittedRevision, query, router]);
+
   const isRedirecting = useRedirectTo404IfFalsy(query.projectRevision);
-  if (isRedirecting) return null;
+  if (isRedirecting || isCommittedRevision) return null;
 
   /**
    *  Function: approve staged change, trigger an insert on the project

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -78,7 +78,7 @@ export function ProjectRevision({
     [query.projectRevision?.formChangesByProjectRevisionId.edges]
   );
   const isCommittedRevision =
-    query.projectRevision.changeStatus === "committed";
+    query.projectRevision?.changeStatus === "committed";
   useEffect(() => {
     if (isCommittedRevision)
       router.push(

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -196,7 +196,7 @@ export function ProjectRevision({
             )}
           </div>
         )}
-        {query.projectRevision.changeStatus != "committed" && (
+        {query.projectRevision.changeStatus !== "committed" && (
           <>
             <Button
               size="medium"

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -35725,6 +35725,11 @@ type Project implements Node {
   """
   id: ID!
 
+  """
+  Returns the latest project revision with a change_status of committed for the given project
+  """
+  latestCommittedProjectRevision: ProjectRevision
+
   """Reads a single `Operator` that is related to this `Project`."""
   operatorByOperatorId: Operator
 

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
@@ -9,7 +9,6 @@ import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledContactsFormQuery, {
   contactsFormQuery,
 } from "__generated__/contactsFormQuery.graphql";
-import { ProjectContactForm_projectRevision$data } from "__generated__/ProjectContactForm_projectRevision.graphql";
 import { ProjectContactForm_query$data } from "__generated__/ProjectContactForm_query.graphql";
 
 jest.mock("next/router");
@@ -76,7 +75,7 @@ describe("The Project Contacts page", () => {
   it("sends a mutation that resets the form to empty when the user clicks the Undo Changes button while adding a new project", () => {
     pageTestingHelper.loadQuery({
       ProjectRevision() {
-        const revision: Partial<ProjectContactForm_projectRevision$data> = {
+        const revision = {
           id: "mock-proj-rev-id",
           rowId: 56,
           projectContactFormChanges: {
@@ -95,7 +94,6 @@ describe("The Project Contacts page", () => {
                 },
               },
             ],
-            __id: "client:WyJwcm9qZWN0X3JldmlzaW9ucyIsNTZd:__connection_projectContactFormChanges_connection",
           },
         };
         return revision;
@@ -146,7 +144,7 @@ describe("The Project Contacts page", () => {
   it("sends a mutation that resets the form to the previous committed data when the user clicks the Undo Changes button while editing an existing project", async () => {
     pageTestingHelper.loadQuery({
       ProjectRevision() {
-        const revision: Partial<ProjectContactForm_projectRevision$data> = {
+        const revision = {
           id: "mock-proj-rev-id",
           rowId: 1,
           projectContactFormChanges: {
@@ -192,8 +190,6 @@ describe("The Project Contacts page", () => {
                 },
               },
             ],
-
-            __id: "client:WyJwcm9qZWN0X3JldmlzaW9ucyIsNjZd:__connection_projectContactFormChanges_connection",
           },
         };
         return revision;
@@ -331,7 +327,7 @@ describe("The Project Contacts page", () => {
 
     pageTestingHelper.loadQuery({
       ProjectRevision(context) {
-        const revision: Partial<ProjectContactForm_projectRevision$data> = {
+        const revision = {
           id: context.path.includes("pendingProjectRevision")
             ? "mock-pending-revision-id"
             : "mock-base-revision-id",
@@ -380,8 +376,6 @@ describe("The Project Contacts page", () => {
                 },
               },
             ],
-
-            __id: "client:WyJwcm9qZWN0X3JldmlzaW9ucyIsNjZd:__connection_projectContactFormChanges_connection",
           },
         };
         return revision;

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
@@ -333,8 +333,8 @@ describe("The Project Contacts page", () => {
       ProjectRevision(context) {
         const revision: Partial<ProjectContactForm_projectRevision$data> = {
           id: context.path.includes("pendingProjectRevision")
-            ? "mock-project-rev-2"
-            : `mock-project-rev-1`,
+            ? "mock-pending-revision-id"
+            : "mock-base-revision-id",
           rowId: 1,
           changeStatus: "committed",
           projectContactFormChanges: {
@@ -424,7 +424,6 @@ describe("The Project Contacts page", () => {
     expect(
       screen.queryByRole("button", { name: "submit" })
     ).not.toBeInTheDocument();
-    screen.logTestingPlaygroundURL();
     expect(screen.getByText(/primary contact/i).nextSibling).toHaveTextContent(
       "Loblaw003, Bob003"
     );
@@ -435,7 +434,7 @@ describe("The Project Contacts page", () => {
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
     expect(routerPush).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/contacts/",
-      query: { projectRevision: "mock-project-rev-2" },
+      query: { projectRevision: "mock-pending-revision-id" },
     });
   });
 });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/managers.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/managers.test.tsx
@@ -363,8 +363,8 @@ describe("The Project Managers form page", () => {
       ProjectRevision(context) {
         return {
           id: context.path.includes("pendingProjectRevision")
-            ? "mock-manager-2"
-            : `mock-manager-1`,
+            ? "mock-pending-revision-id"
+            : "mock-base-revision-id",
           projectByProjectId: {
             latestCommittedProjectRevision: {
               id: "mock-manager-1",
@@ -464,7 +464,7 @@ describe("The Project Managers form page", () => {
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
     expect(routerPush).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/managers/",
-      query: { projectRevision: "mock-manager-2" },
+      query: { projectRevision: "mock-pending-revision-id" },
     });
   });
 });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
@@ -329,8 +329,8 @@ describe("The Project Overview page", () => {
       ProjectRevision(context) {
         return {
           id: context.path.includes("pendingProjectRevision")
-            ? "mock-project-rev-2"
-            : `mock-project-rev-1`,
+            ? "mock-pending-revision-id"
+            : "mock-base-revision-id",
           changeStatus: "committed",
 
           projectFormChange: {
@@ -426,7 +426,7 @@ describe("The Project Overview page", () => {
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
     expect(routerPush).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/overview/",
-      query: { projectRevision: "mock-project-rev-2" },
+      query: { projectRevision: "mock-pending-revision-id" },
     });
   });
 });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
@@ -326,10 +326,13 @@ describe("The Project Overview page", () => {
     mocked(useRouter).mockReturnValue({ push: routerPush } as any);
 
     pageTestingHelper.loadQuery({
-      ProjectRevision() {
+      ProjectRevision(context) {
         return {
-          id: "mock-rev-id",
+          id: context.path.includes("pendingProjectRevision")
+            ? "mock-project-rev-2"
+            : `mock-project-rev-1`,
           changeStatus: "committed",
+
           projectFormChange: {
             id: "mock-project-form-id",
             newFormData: {
@@ -422,7 +425,7 @@ describe("The Project Overview page", () => {
 
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
     expect(routerPush).toHaveBeenCalledWith({
-      pathname: "/cif/project-revision/[projectRevision]/form/contacts/",
+      pathname: "/cif/project-revision/[projectRevision]/form/overview/",
       query: { projectRevision: "mock-project-rev-2" },
     });
   });

--- a/schema/deploy/computed_columns/project_latest_committed_project_revision.sql
+++ b/schema/deploy/computed_columns/project_latest_committed_project_revision.sql
@@ -10,7 +10,7 @@ as
 $function$
   select *
   from cif.project_revision
-  where project_id =1
+  where project_id = $1.id
   and change_status = 'committed'
   order by updated_at desc
   fetch first row only;

--- a/schema/deploy/computed_columns/project_latest_committed_project_revision.sql
+++ b/schema/deploy/computed_columns/project_latest_committed_project_revision.sql
@@ -1,0 +1,21 @@
+-- Deploy cif:computed_columns/project_latest_committed_project_revision to pg
+-- requires: tables/project
+-- requires: tables/project_revision
+
+begin;
+
+create or replace function cif.project_latest_committed_project_revision(cif.project)
+returns cif.project_revision
+as
+$function$
+  select *
+  from cif.project_revision
+  where project_id =1
+  and change_status = 'committed'
+  order by updated_at desc
+  fetch first row only;
+$function$ language sql stable;
+
+comment on function cif.project_latest_committed_project_revision(cif.project) is 'Returns the latest project revision with a change_status of committed for the given project';
+
+commit;

--- a/schema/revert/computed_columns/project_latest_committed_project_revision.sql
+++ b/schema/revert/computed_columns/project_latest_committed_project_revision.sql
@@ -1,0 +1,7 @@
+-- Revert cif:computed_columns/project_latest_committed_project_revision from pg
+
+begin;
+
+drop function cif.project_latest_committed_project_revision;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -74,3 +74,4 @@ tables/reporting_requirement 2022-04-29T22:15:51Z Sepehr Sobhani <sepehr.sobhani
 tables/budget_item_category 2022-05-03T19:37:07Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Create the cif.budget_item_category table
 tables/budget_item 2022-05-02T18:26:46Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Create the cif.budget_item table
 tables/payment 2022-05-02T19:01:17Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Create the cif.payment table
+computed_columns/project_latest_committed_project_revision [tables/project tables/project_revision] 2022-05-02T18:21:58Z Mike Vesprini <mike@button.is> # A computed column returning the latest committed revision for a project

--- a/schema/test/unit/computed_columns/project_latest_committed_project_revision_test.sql
+++ b/schema/test/unit/computed_columns/project_latest_committed_project_revision_test.sql
@@ -1,0 +1,57 @@
+begin;
+
+select plan(3);
+
+set jwt.claims.sub to '11111111-1111-1111-1111-111111111111';
+
+insert into cif.cif_user(id, uuid)
+  overriding system value
+  values (1, '11111111-1111-1111-1111-111111111111');
+
+insert into cif.operator (id, legal_name, trade_name, bc_registry_id, operator_code)
+overriding system value
+values
+  (1, 'first operator legal name', 'first operator trade name', 'AB1234567', 'ABCD');
+
+insert into cif.project(id, operator_id, funding_stream_rfp_id, project_status_id, proposal_reference, summary, project_name)
+overriding system value
+values
+  (1, 1, 1, 1, '000', 'summary', 'project 1'),
+  (2, 1, 1, 1, '001', 'summary', 'project 2');
+
+insert into cif.project_revision(id, change_status, change_reason, project_id)
+overriding system value
+values
+  (1, 'committed', 'reason for change', 1),
+  (2, 'pending', 'reason for change', 2),
+  (3, 'pending', 'reason for change', 1);
+
+
+select is (
+  (select id from cif.project_latest_committed_project_revision(
+    (select row(project.*)::cif.project from cif.project where id=1)
+  )),
+  1::integer,
+  'returns the latest project revision for the project when there is only one committed revision'
+);
+
+update cif.project_revision set change_status = 'committed' where id = 3;
+
+select is (
+  (select id from cif.project_latest_committed_project_revision(
+    (select row(project.*)::cif.project from cif.project where id=1)
+  )),
+  3::integer,
+  'returns the latest committed project revision for the project when there are multiple committed revisions'
+);
+
+select is (
+  (select id from cif.project_latest_committed_project_revision(
+    (select row(project.*)::cif.project from cif.project where id=2)
+  )),
+  null,
+  'returns null when there is no committed project revision for the project'
+);
+
+select finish();
+rollback;

--- a/schema/verify/computed_columns/project_latest_committed_project_revision.sql
+++ b/schema/verify/computed_columns/project_latest_committed_project_revision.sql
@@ -1,0 +1,7 @@
+-- Verify cif:computed_columns/project_latest_committed_project_revision on pg
+
+begin;
+
+select pg_get_functiondef('cif.project_latest_committed_project_revision(cif.project)'::regprocedure);
+
+rollback;


### PR DESCRIPTION
Display forms in read-only mode when viewing a committed project revision.
Includes a computed column for the latest committed project revision on a project.
Includes a hook to redirect to the latest committed project revision.