### PR TITLE
Fix: Show custom instead of default 500 page

### DIFF
--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -7,7 +7,7 @@ import {
   GraphQLTaggedNode,
   useRelayEnvironment,
 } from "react-relay";
-import Sentry from "@sentry/react";
+import * as Sentry from "@sentry/react";
 import FilterRow from "./FilterRow";
 import { FilterArgs, PageArgs, TableFilter } from "./Filters";
 import Pagination from "./Pagination";

--- a/app/cypress/integration/cif/500.spec.js
+++ b/app/cypress/integration/cif/500.spec.js
@@ -8,7 +8,7 @@ describe("The 500 page", () => {
     cy.visit("/");
     cy.visit("/500", { failOnStatusCode: false });
     cy.get("body").happoScreenshot({
-      component: "500 page",
+      component: "500 page server-side",
     });
     cy.get("a[href='javascript:;']").click();
     cy.url().should("eq", Cypress.config().baseUrl + "/");

--- a/app/lib/relay/withRelayOptions.tsx
+++ b/app/lib/relay/withRelayOptions.tsx
@@ -8,9 +8,19 @@ import { NextRouter } from "next/router";
 import safeJsonParse from "lib/safeJsonParse";
 import { DEFAULT_PAGE_SIZE } from "components/Table/Pagination";
 import LoadingFallback from "components/Layout/LoadingFallback";
+import * as Sentry from "@sentry/react";
+import Error from "components/Error";
 
 const withRelayOptions: WiredOptions<any> = {
   fallback: <LoadingFallback />,
+  ErrorComponent: () => (
+    <Sentry.ErrorBoundary
+      fallback={<Error />}
+      onError={() => {
+        console.log("is this onerror function called");
+      }}
+    />
+  ),
   createClientEnvironment: () => getClientEnvironment()!,
   createServerEnvironment: async (ctx: NextPageContext) => {
     const { createServerEnvironment } = await import("./server");

--- a/app/lib/relay/withRelayOptions.tsx
+++ b/app/lib/relay/withRelayOptions.tsx
@@ -8,19 +8,13 @@ import { NextRouter } from "next/router";
 import safeJsonParse from "lib/safeJsonParse";
 import { DEFAULT_PAGE_SIZE } from "components/Table/Pagination";
 import LoadingFallback from "components/Layout/LoadingFallback";
-import * as Sentry from "@sentry/react";
-import Custom500 from "pages/500";
 
 const withRelayOptions: WiredOptions<any> = {
   fallback: <LoadingFallback />,
-  ErrorComponent: () => (
-    <Sentry.ErrorBoundary
-      fallback={<Custom500 />}
-      onError={() => {
-        console.log("is this onerror function called");
-      }}
-    />
-  ),
+  ErrorComponent: (props) => {
+    // error will be handled by sentry error boundary in _app.tsx
+    throw props.error;
+  },
   createClientEnvironment: () => getClientEnvironment()!,
   createServerEnvironment: async (ctx: NextPageContext) => {
     const { createServerEnvironment } = await import("./server");

--- a/app/lib/relay/withRelayOptions.tsx
+++ b/app/lib/relay/withRelayOptions.tsx
@@ -9,13 +9,13 @@ import safeJsonParse from "lib/safeJsonParse";
 import { DEFAULT_PAGE_SIZE } from "components/Table/Pagination";
 import LoadingFallback from "components/Layout/LoadingFallback";
 import * as Sentry from "@sentry/react";
-import Error from "components/Error";
+import Custom500 from "pages/500";
 
 const withRelayOptions: WiredOptions<any> = {
   fallback: <LoadingFallback />,
   ErrorComponent: () => (
     <Sentry.ErrorBoundary
-      fallback={<Error />}
+      fallback={<Custom500 />}
       onError={() => {
         console.log("is this onerror function called");
       }}

--- a/app/package.json
+++ b/app/package.json
@@ -121,7 +121,7 @@
     "react-relay-network-modern": "^6.2.1",
     "react-typography": "^0.16.20",
     "relay-compiler": "^13.0.1",
-    "relay-nextjs": "^0.4.1",
+    "relay-nextjs": "0.8.0",
     "relay-runtime": "^13.0.1",
     "relay-test-utils": "^13.0.1",
     "styled-components": "^5.2.1",

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -41,10 +41,10 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <ErrorContext.Provider value={value}>
+      <BCGovTypography />
       <Sentry.ErrorBoundary fallback={<Custom500 />}>
         <RelayEnvironmentProvider environment={env}>
           {typeof window !== "undefined" && <SessionExpiryHandler />}
-          <BCGovTypography />
           {component}
         </RelayEnvironmentProvider>
       </Sentry.ErrorBoundary>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -6,13 +6,13 @@ import BCGovTypography from "components/BCGovTypography";
 import SessionExpiryHandler from "components/Session/SessionExpiryHandler";
 import { Suspense, useEffect, useState } from "react";
 import * as Sentry from "@sentry/react";
-import ErrorFallback from "./500";
-import { ErrorContext } from "contexts/ErrorContext";
 
+import { ErrorContext } from "contexts/ErrorContext";
 import "normalize.css";
 import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import LoadingFallback from "components/Layout/LoadingFallback";
+import Custom500 from "./500";
 config.autoAddCss = false;
 
 const clientEnv = getClientEnvironment();
@@ -41,7 +41,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <ErrorContext.Provider value={value}>
-      <Sentry.ErrorBoundary fallback={ErrorFallback}>
+      <Sentry.ErrorBoundary fallback={<Custom500 />}>
         <RelayEnvironmentProvider environment={env}>
           {typeof window !== "undefined" && <SessionExpiryHandler />}
           <BCGovTypography />

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -8330,10 +8330,10 @@ relay-compiler@^13.0.1:
   resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-13.0.1.tgz#09c713647aa7e1d8cf3de9f7fb4ee6a76b32cf26"
   integrity sha512-C/qJ7IdfZ140b9JaNpuAP6WhV/Odt/tIq4sUZoTwsaOlhs+1Zu3fvIOoWKTnZT5PC6krRuw1hD7GSX6/paVpTQ==
 
-relay-nextjs@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/relay-nextjs/-/relay-nextjs-0.4.1.tgz#48971dd95d91d5e95a58ba8603db2ec46e2d0b01"
-  integrity sha512-L69F61or5M3VioqcI8sV8TWhx4MVb5EpceDGGxMZtxWQCsM/xVVr3hNqvx71Gm4DB/eGM4ccNn2reWh44PvLQQ==
+relay-nextjs@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/relay-nextjs/-/relay-nextjs-0.8.0.tgz#cb2832e984339fb30448c30f4c9c44191074ba88"
+  integrity sha512-rOR1o8uTmIe6lcILT9AsINBgogAD3wm5gnM3SBFy8IEj68a8ViA2o1Qy1zfCXr3hXOOThFThD1nbXtd9AUi9tQ==
   dependencies:
     serialize-javascript "^5.0.1"
 


### PR DESCRIPTION
Issue https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/359

Notes:
- if you want to pull the branch and check it out locally, you have to build and `yarn start` If you're not in production, [you get the stack instead of the page](https://nextjs.org/docs/advanced-features/custom-error-page#:~:text=pages/_error.js%20is%20only%20used%20in%20production.%20In%20development%20you%E2%80%99ll%20get%20an%20error%20with%20the%20call%20stack%20to%20know%20where%20the%20error%20originated%20from.)