### PR TITLE
Use Certbot to manage SSL certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,12 +209,13 @@ lint_chart:
 .PHONY: install
 install: ## Installs the helm chart on the OpenShift cluster
 install: GIT_SHA1=$(shell git rev-parse HEAD)
+install: IMAGE_TAG=$(GIT_SHA1)
 install: NAMESPACE=$(CIF_NAMESPACE_PREFIX)-$(ENVIRONMENT)
 install: GGIRCS_NAMESPACE=$(GGIRCS_NAMESPACE_PREFIX)-$(ENVIRONMENT)
 install: CHART_DIR=./chart/cas-cif
 install: CHART_INSTANCE=cas-cif
 install: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
-										--set defaultImageTag=$(GIT_SHA1) \
+										--set defaultImageTag=$(IMAGE_TAG) \
 	  								--set download-dags.dagConfiguration="$$dagConfig" \
 										--set ggircs.namespace=$(GGIRCS_NAMESPACE) \
 										--set ciip.prefix=$(CIIP_NAMESPACE_PREFIX) \
@@ -242,6 +243,6 @@ install:
 	if ! helm status --namespace $(NAMESPACE) $(CHART_INSTANCE); then \
 		echo 'Installing the application and issuing SSL certificate'; \
 		helm install --set certbot.manualRun=true $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
-	else; \
+	else \
 		helm upgrade $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,6 @@ install:
 	helm dep up $(CHART_DIR); \
 	if ! helm status --namespace $(NAMESPACE) $(CHART_INSTANCE); then \
 		echo 'Installing the application and issuing SSL certificate'; \
-		helm install $(HELM_OPTS) --set cert-issue.enabled=true --set nginx-sidecar.sslTermination=false $(CHART_INSTANCE) $(CHART_DIR); \
+		helm install $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
 	fi; \
 	helm upgrade $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR);

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ install:
 	helm dep up $(CHART_DIR); \
 	if ! helm status --namespace $(NAMESPACE) $(CHART_INSTANCE); then \
 		echo 'Installing the application and issuing SSL certificate'; \
-		helm install $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
-	fi; \
-	helm upgrade $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR);
+		helm install --set certbot.manualRun=true $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
+	else; \
+		helm upgrade $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
+	fi;

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -24,8 +24,9 @@ const handle = app.getRequestHandler();
 app.prepare().then(async () => {
   const server = express();
 
-  // nginx proxy is running in the same pod
-  server.set("trust proxy", "loopback");
+  // trust the first proxy, so that secure cookies are set,
+  // even though the request reaching the express container is not secure
+  server.set("trust proxy", 1);
 
   const lightship = createLightship();
 

--- a/chart/cas-cif/Chart.lock
+++ b/chart/cas-cif/Chart.lock
@@ -5,11 +5,5 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.0.7
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.0.7
-- name: nginx-sidecar
-  repository: https://bcgov.github.io/cas-template-app
-  version: 0.1.8
-digest: sha256:b910ee2fd21144d1b1f9d11dd7ae14039f88cbe16119cbac85ff731717091926
-generated: "2022-04-07T16:08:29.643036823-07:00"
+digest: sha256:6be971357d4017886a4dbf7a9c46fb505df6ef4ffbe44d47ac5907c537f4887b
+generated: "2022-05-05T13:40:21.872342317-07:00"

--- a/chart/cas-cif/Chart.lock
+++ b/chart/cas-cif/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.0.7
-digest: sha256:6be971357d4017886a4dbf7a9c46fb505df6ef4ffbe44d47ac5907c537f4887b
-generated: "2022-05-05T13:40:21.872342317-07:00"
+- name: certbot
+  repository: https://bcdevops.github.io/certbot
+  version: 0.1.0
+digest: sha256:39cf5f0492b8729096b8d42dfd5c23929ff4e5476ebd337c4637feb7bdf247e5
+generated: "2022-05-10T12:58:45.87284267-07:00"

--- a/chart/cas-cif/Chart.yaml
+++ b/chart/cas-cif/Chart.yaml
@@ -12,12 +12,4 @@ dependencies:
   - name: cas-airflow-dag-trigger
     version: 1.0.7
     repository: https://bcgov.github.io/cas-airflow
-    alias: cert-issue
-    condition: cert-issue.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.0.7
-    repository: https://bcgov.github.io/cas-airflow
     alias: deploy-db
-  - name: nginx-sidecar
-    repository: https://bcgov.github.io/cas-template-app
-    version: 0.1.8

--- a/chart/cas-cif/Chart.yaml
+++ b/chart/cas-cif/Chart.yaml
@@ -13,3 +13,6 @@ dependencies:
     version: 1.0.7
     repository: https://bcgov.github.io/cas-airflow
     alias: deploy-db
+  - name: certbot
+    version: 0.1.0
+    repository: https://bcdevops.github.io/certbot

--- a/chart/cas-cif/templates/app-deployment.yaml
+++ b/chart/cas-cif/templates/app-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           - name: SITEWIDE_NOTICE
             value: {{ .Values.app.sitewide_notice.content | quote }}
           - name: HOST
-            value: http{{ if index .Values "nginx-sidecar" "sslTermination" }}s{{ end }}://{{ index .Values "nginx-sidecar" "hostName" }}
+            value: https://{{ .Values.hostName }}
           - name: SENTRY_ENVIRONMENT
             value: {{ include "cas-cif.namespaceSuffix" . }}
           - name: SENTRY_RELEASE
@@ -119,7 +119,6 @@ spec:
           - mountPath: "/attachments-credentials"
             name: gcs-documents-credentials
             readOnly: true
-{{- include "nginx-sidecar.deployment-container.tpl" (index .Values "nginx-sidecar") | indent 6 }}
       volumes:
         - name: gcs-documents-credentials
           secret:
@@ -127,5 +126,4 @@ spec:
             items:
             - key: credentials.json
               path: attachments-credentials.json
-{{- include "nginx-sidecar.deployment-volumes.tpl" (index .Values "nginx-sidecar") | nindent 8 }}
       restartPolicy: Always

--- a/chart/cas-cif/templates/route.yaml
+++ b/chart/cas-cif/templates/route.yaml
@@ -1,3 +1,13 @@
+{{- $route := (lookup "route.openshift.io/v1" "Route" .Release.Namespace "cas-cif" ) }}
+{{- $certificate := "" }}
+{{- $key := "" }}
+{{- $caCertificate := "" }}
+{{- if $route }}
+{{- $certificate = $route.spec.tls.certificate }}
+{{- $key = $route.spec.tls.key }}
+{{- $caCertificate = $route.spec.tls.caCertificate }}
+{{- end -}}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -12,6 +22,11 @@ spec:
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
+    {{- if $route }}
+    certificate: {{ $certificate | quote }}
+    key: {{ $key | quote }}
+    caCertificate: {{ $caCertificate | quote }}
+    {{- end }}
   to:
     kind: Service
     name: {{ template "cas-cif.fullname" . }}

--- a/chart/cas-cif/templates/route.yaml
+++ b/chart/cas-cif/templates/route.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
-    {{- if $route }}
+    {{- if $certificate }}
     certificate: {{ $certificate | quote }}
     key: {{ $key | quote }}
     caCertificate: {{ $caCertificate | quote }}

--- a/chart/cas-cif/templates/route.yaml
+++ b/chart/cas-cif/templates/route.yaml
@@ -1,18 +1,17 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: {{ template "cas-cif.fullname" . }}{{ if not (index .Values "nginx-sidecar" "sslTermination") }}-insecure{{ end }}
+  name: {{ template "cas-cif.fullname" . }}
   labels: {{ include "cas-cif.labels" . | nindent 4 }}
+    certbot-managed: "true"
 
 spec:
-  host: {{ index .Values "nginx-sidecar" "hostName" }}
+  host: {{ .Values.hostName }}
   port:
     targetPort: {{ template "cas-cif.fullname" . }}
-{{- if index .Values "nginx-sidecar" "sslTermination" }}
   tls:
-    termination: passthrough
+    termination: edge
     insecureEdgeTerminationPolicy: Redirect
-{{- end }}
   to:
     kind: Service
     name: {{ template "cas-cif.fullname" . }}

--- a/chart/cas-cif/templates/service.yaml
+++ b/chart/cas-cif/templates/service.yaml
@@ -9,11 +9,7 @@ spec:
   - name: {{ template "cas-cif.fullname" . }}
     port: {{ .Values.app.port }}
     protocol: TCP
-    {{- if (index .Values "nginx-sidecar") }}
-    targetPort: {{ index .Values "nginx-sidecar" "port" }}
-    {{- else }}
     targetPort: 3000
-    {{- end }}
   selector: {{ include "cas-cif.selectorLabels" . | nindent 4 }}
     component: app
   sessionAffinity: None

--- a/chart/cas-cif/values-dev.yaml
+++ b/chart/cas-cif/values-dev.yaml
@@ -3,8 +3,7 @@ app:
   sitewide_notice:
     content: <div class="alert alert-warning">This is the DEV environment.</div>
 
-nginx-sidecar:
-  hostName: dev.cif.gov.bc.ca
+hostName: dev.cif.gov.bc.ca
 
 db:
   preUpgradeCommand: |
@@ -13,9 +12,6 @@ db:
       drop schema if exists cif cascade;
       drop schema if exists cif_private cascade;
     EOF
-
-cert-issue:
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values-prod.yaml
+++ b/chart/cas-cif/values-prod.yaml
@@ -1,11 +1,8 @@
-nginx-sidecar:
-  hostName: cif.gov.bc.ca
-  caServerSecret: cas-acme-url
-  caServerKey: url
-  renewalDays: 305
+hostName: cif.gov.bc.ca
 
-cert-issue:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
+caServerSecret: cas-acme-url
+caServerKey: url
+renewalDays: 305
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values-prod.yaml
+++ b/chart/cas-cif/values-prod.yaml
@@ -1,8 +1,10 @@
 hostName: cif.gov.bc.ca
 
-caServerSecret: cas-acme-url
-caServerKey: url
-renewalDays: 305
+certbot:
+  certbot:
+    server:
+      secretName: cas-acme-url
+      secretKey: url
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values-test.yaml
+++ b/chart/cas-cif/values-test.yaml
@@ -2,8 +2,7 @@ app:
   sitewide_notice:
     content: <div class="alert alert-warning">This is the TEST environment.</div>
 
-nginx-sidecar:
-  hostName: test.cif.gov.bc.ca
+hostName: test.cif.gov.bc.ca
 
 db:
   preUpgradeCommand: |
@@ -12,9 +11,6 @@ db:
       drop schema if exists cif cascade;
       drop schema if exists cif_private cascade;
     EOF
-
-cert-issue:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -35,6 +35,8 @@ hostName: ~
 port: 3001
 
 certbot:
+  image:
+    tag: "1.0"
   certbot:
     email: ggircs@gov.bc.ca
 

--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -30,19 +30,18 @@ db:
   # A shell script that will be executed in a pre-upgrade job, on the psql image.
   preUpgradeCommand: ~
 
-nginx-sidecar:
-  hostName: ~
-  # set to false to deploy the application with an insecure route,
-  # and issue an SSL certificate using acme.sh
-  sslTermination: true
-  objectNamePrefix: cas-cif
-  port: 3001
-  internalPort: 3000
-  caServerSecret: ~ # pragma: allowlist secret
-  caServerKey: ~
-  caAccountEmail: ggircs@gov.bc.ca
-  storageClassName: netapp-file-standard
-  renewalDays: 60
+hostName: ~
+# set to false to deploy the application with an insecure route,
+# and issue an SSL certificate using acme.sh
+sslTermination: true
+objectNamePrefix: cas-cif
+port: 3001
+internalPort: 3000
+caServerSecret: ~ # pragma: allowlist secret
+caServerKey: ~
+caAccountEmail: ggircs@gov.bc.ca
+storageClassName: netapp-file-standard
+renewalDays: 60
 
 resources:
   limits:
@@ -58,13 +57,6 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
-cert-issue:
-  enabled: false
-  airflowEndpoint: ~
-  dagId: cas_cif_acme_issue
-  helm:
-    hook: post-install
 
 deploy-db:
   airflowEndpoint: ~

--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -32,8 +32,6 @@ db:
 
 hostName: ~
 
-port: 3001
-
 certbot:
   image:
     tag: "1.0"

--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -31,17 +31,12 @@ db:
   preUpgradeCommand: ~
 
 hostName: ~
-# set to false to deploy the application with an insecure route,
-# and issue an SSL certificate using acme.sh
-sslTermination: true
-objectNamePrefix: cas-cif
+
 port: 3001
-internalPort: 3000
-caServerSecret: ~ # pragma: allowlist secret
-caServerKey: ~
-caAccountEmail: ggircs@gov.bc.ca
-storageClassName: netapp-file-standard
-renewalDays: 60
+
+certbot:
+  certbot:
+    email: ggircs@gov.bc.ca
 
 resources:
   limits:

--- a/dags/cas_cif_dags.py
+++ b/dags/cas_cif_dags.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from dag_configuration import default_dag_args
 from trigger_k8s_cronjob import trigger_k8s_cronjob
-from reload_nginx_containers import reload_nginx_containers
-from walg_backups import create_backup_task
 from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 from airflow import DAG
@@ -14,9 +12,6 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 TWO_DAYS_AGO = datetime.now() - timedelta(days=2)
 
 DEPLOY_DB_DAG_NAME = 'cas_cif_deploy_db'
-CERT_RENEWAL_DAG_NAME = 'cas_cif_acme_renewal'
-CERT_ISSUE_DAG_NAME = 'cas_cif_acme_issue'
-BACKUP_DAG_NAME = 'cas_cif_backup'
 
 cif_namespace = os.getenv('CIF_NAMESPACE')
 
@@ -57,52 +52,3 @@ cif_import_operator = PythonOperator(
 
 
 cif_db_init >> cif_app_schema >> cif_import_operator
-
-"""
-###############################################################################
-#                                                                             #
-# DAG triggering the cas-cif-acme-renewal cron job                         #
-#                                                                             #
-###############################################################################
-"""
-SCHEDULE_INTERVAL = '0 8 * * *'
-
-acme_renewal_args = {
-    **default_dag_args,
-    'start_date': TWO_DAYS_AGO,
-    'is_paused_upon_creation': False
-}
-
-"""
-DAG cas_cif_issue
-Issues site certificates for the cif app
-"""
-acme_issue_dag = DAG(CERT_ISSUE_DAG_NAME,
-                     schedule_interval=None, default_args=acme_renewal_args)
-
-cron_acme_issue_task = PythonOperator(
-    python_callable=trigger_k8s_cronjob,
-    task_id='cas_cif_cert_issue',
-    op_args=['cas-cif-acme-issue', cif_namespace],
-    dag=acme_issue_dag)
-
-"""
-DAG cas_cif_acme_renewal
-Renews site certificates for the cif app
-"""
-acme_renewal_dag = DAG(CERT_RENEWAL_DAG_NAME, schedule_interval=SCHEDULE_INTERVAL,
-                       default_args=acme_renewal_args, is_paused_upon_creation=True)
-
-cert_renewal_task = PythonOperator(
-    python_callable=trigger_k8s_cronjob,
-    task_id='cas_cif_cert_renewal',
-    op_args=['cas-cif-acme-renewal', cif_namespace],
-    dag=acme_renewal_dag)
-
-reload_nginx_task = PythonOperator(
-    python_callable=reload_nginx_containers,
-    task_id='cas_cif_reload_nginx',
-    op_args=['cas-cif', cif_namespace],
-    dag=acme_renewal_dag)
-
-cert_renewal_task >> reload_nginx_task


### PR DESCRIPTION
This depends on https://github.com/BCDevOps/certbot/pull/18 being merged and the certbot Helm chart being published.

Once that's done a `helm dep up` command needs to be run to update the `Chart.lock`