### PR TITLE
chore: remove default image from postgres.yaml

### DIFF
--- a/chart/cas-cif/templates/postgres.yaml
+++ b/chart/cas-cif/templates/postgres.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   metadata:
     labels: {{ include "cas-cif.labels" . | nindent 6 }}
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.2-0
   postgresVersion: 14
   instances:
     - name: pgha1
@@ -45,7 +44,6 @@ spec:
       config:
         global:
           client_tls_sslmode: disable
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
       replicas: 2
       affinity:
         podAntiAffinity:
@@ -92,4 +90,4 @@ spec:
   monitoring:
     pgmonitor:
       exporter:
-        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+

--- a/chart/cas-cif/templates/postgres.yaml
+++ b/chart/cas-cif/templates/postgres.yaml
@@ -22,6 +22,15 @@ spec:
             cpu: 1000m
             memory: 2Gi
         storageClassName: netapp-block-standard
+      sidecars:
+        replicaCertCopy:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -90,4 +99,10 @@ spec:
   monitoring:
     pgmonitor:
       exporter:
-
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi


### PR DESCRIPTION
Issue #527 

I left in the proxy and monitoring images because they seem to be required per the docs: https://access.crunchydata.com/documentation/postgres-operator/v5/references/crd/#:~:text=When%20omitted%2C%20the%20value%20comes%20from%20an%20operator%20environment%20variable.