### PR TITLE
Feat: discard confirmation

### DIFF
--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -19,6 +19,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   getProjectsPageRoute,
   getProjectRevisionOverviewFormPageRoute,
+  getProjectRevisionPageRoute,
 } from "pageRoutes";
 import useRedirectTo404IfFalsy from "hooks/useRedirectTo404IfFalsy";
 import TaskList from "components/TaskList";
@@ -33,6 +34,7 @@ const pageQuery = graphql`
       }
       projectRevision(id: $projectRevision) {
         id
+        isFirstRevision
         changeReason
         changeStatus
         projectId
@@ -40,6 +42,11 @@ const pageQuery = graphql`
         ...ProjectContactFormSummary_projectRevision
         ...ProjectManagerFormSummary_projectRevision
         ...TaskList_projectRevision
+        projectByProjectId {
+          latestCommittedProjectRevision {
+            id
+          }
+        }
         formChangesByProjectRevisionId {
           edges {
             node {
@@ -145,7 +152,15 @@ export function ProjectRevision({
         },
       },
       onCompleted: async () => {
-        await router.push(getProjectsPageRoute());
+        if (query.projectRevision.isFirstRevision)
+          await router.push(getProjectsPageRoute());
+        else
+          await router.push(
+            getProjectRevisionPageRoute(
+              query.projectRevision.projectByProjectId
+                .latestCommittedProjectRevision.id
+            )
+          );
       },
       onError: async (e) => {
         console.error("Error discarding the project", e);

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -7,12 +7,14 @@ import { graphql, usePreloadedQuery } from "react-relay/hooks";
 import { ProjectRevisionQuery } from "__generated__/ProjectRevisionQuery.graphql";
 import withRelayOptions from "lib/relay/withRelayOptions";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
-import { Button, Textarea } from "@button-inc/bcgov-theme";
+import { useEffect, useState } from "react";
+import { Button, Textarea, Alert } from "@button-inc/bcgov-theme";
 import { mutation as updateProjectRevisionMutation } from "mutations/ProjectRevision/updateProjectRevision";
 import { useUpdateChangeReason } from "mutations/ProjectRevision/updateChangeReason";
 import { useDeleteProjectRevisionMutation } from "mutations/ProjectRevision/deleteProjectRevision";
 import SavingIndicator from "components/Form/SavingIndicator";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import {
   getProjectsPageRoute,
@@ -54,6 +56,7 @@ export function ProjectRevision({
   preloadedQuery,
 }: RelayProps<{}, ProjectRevisionQuery>) {
   const router = useRouter();
+  const [showDiscardConfirmation, setShowDiscardConfirmation] = useState(false);
   const { query } = usePreloadedQuery(pageQuery, preloadedQuery);
 
   const [updateChangeReason, updatingChangeReason] = useUpdateChangeReason();
@@ -157,6 +160,27 @@ export function ProjectRevision({
       <div>
         <header>
           <h2>Review and Submit Project</h2>
+          {showDiscardConfirmation && (
+            <Alert variant="danger" size="sm">
+              All changes made will be permanently deleted.
+              <a id="confirm-discard-revision" onClick={discardRevision}>
+                Proceed
+              </a>
+              <a onClick={() => setShowDiscardConfirmation(false)}>Cancel</a>
+            </Alert>
+          )}
+          {!showDiscardConfirmation && (
+            <Button
+              id="discard-project-button"
+              size="small"
+              variant="secondary"
+              onClick={() => setShowDiscardConfirmation(true)}
+              disabled={updatingProjectRevision || discardingProjectRevision}
+            >
+              <FontAwesomeIcon icon={faTrash} id="discard-project-icon" />
+              Discard Project Revision
+            </Button>
+          )}
         </header>
         <ProjectFormSummary projectRevision={query.projectRevision} />
         <ProjectManagerFormSummary projectRevision={query.projectRevision} />
@@ -200,14 +224,6 @@ export function ProjectRevision({
             >
               Submit
             </Button>
-            <Button
-              size="medium"
-              variant="secondary"
-              onClick={discardRevision}
-              disabled={updatingProjectRevision || discardingProjectRevision}
-            >
-              Discard Changes
-            </Button>
           </>
         )}
       </div>
@@ -224,6 +240,32 @@ export function ProjectRevision({
         }
         h4 {
           margin-bottom: 0;
+        }
+        div :global(#discard-project-icon) {
+          color: #323a45;
+          margin-right: 0.5em;
+        }
+        div :global(#discard-project-button) {
+          margin-bottom: 1em;
+          color: #cd2026;
+        }
+        div :global(#discard-project-button:hover) {
+          background-color: #aeb0b5;
+        }
+        div :global(.pg-notification) {
+          margin-bottom: 1em;
+        }
+        div :global(a) {
+          color: #1a5a96;
+        }
+        div :global(a:hover) {
+          text-decoration: none;
+          color: blue;
+          cursor: pointer;
+        }
+        div :global(#confirm-discard-revision) {
+          margin-left: 2em;
+          margin-right: 1em;
         }
       `}</style>
     </DefaultLayout>

--- a/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
@@ -72,7 +72,7 @@ describe("The Create Project page", () => {
     jest
       .spyOn(require("mutations/useDebouncedMutation"), "default")
       .mockImplementation(() => [jest.fn(), false]);
-    const mockresolver = {
+    const mockResolver = {
       ...defaultMockResolver,
       FormChange() {
         return {
@@ -80,7 +80,7 @@ describe("The Create Project page", () => {
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
     expect(screen.getByText("Submit")).not.toBeDisabled();
     expect(screen.getByText("Discard Project Revision")).toHaveProperty(
@@ -323,7 +323,7 @@ describe("The Create Project page", () => {
   });
 
   it("displays an error when the Submit Button is clicked & updateProjectRevisionMutation fails", () => {
-    const mockresolver = {
+    const mockResolver = {
       ...defaultMockResolver,
       FormChange() {
         return {
@@ -331,7 +331,7 @@ describe("The Create Project page", () => {
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
     userEvent.click(screen.queryByText("Submit"));
     act(() => {
@@ -385,7 +385,7 @@ describe("The Create Project page", () => {
   });
 
   it("submit is disabled if primary contact is empty", () => {
-    const mockresolver = {
+    const mockResolver = {
       ...defaultMockResolver,
       projectContactFormChanges() {
         return {
@@ -403,13 +403,13 @@ describe("The Create Project page", () => {
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
     expect(screen.getByText("Submit")).toBeDisabled();
   });
 
   it("submit is disabled if there are any validation errors", () => {
-    const mockresolver = {
+    const mockResolver = {
       ...defaultMockResolver,
       FormChange() {
         return {
@@ -417,12 +417,12 @@ describe("The Create Project page", () => {
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
     expect(screen.getByText("Submit")).toBeDisabled();
   });
   it("submit is enabled if there are no validation errors", () => {
-    const mockresolver = {
+    const mockResolver = {
       ...defaultMockResolver,
       FormChange() {
         return {
@@ -430,7 +430,7 @@ describe("The Create Project page", () => {
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
     expect(screen.getByText("Submit")).toBeEnabled();
   });
@@ -441,22 +441,14 @@ describe("The Create Project page", () => {
       push: jest.fn(),
     } as any);
 
-    const mockresolver = {
+    const mockResolver = {
       ProjectRevision() {
         return {
-          id: "mock-proj-rev-id",
           isFirstRevision: true,
-          projectByProjectId: null,
-          projectFormChange: {
-            id: "mock-project-form-id",
-            newFormData: {
-              someProjectData: "test2",
-            },
-          },
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
 
     userEvent.click(screen.queryByText("Discard Project Revision"));
@@ -479,7 +471,7 @@ describe("The Create Project page", () => {
       push: jest.fn(),
     } as any);
 
-    const mockresolver = {
+    const mockResolver = {
       ProjectRevision() {
         return {
           id: "mock-proj-rev-id",
@@ -489,16 +481,10 @@ describe("The Create Project page", () => {
               id: "last-revision-id",
             },
           },
-          projectFormChange: {
-            id: "mock-project-form-id",
-            newFormData: {
-              someProjectData: "test2",
-            },
-          },
         };
       },
     };
-    pageTestingHelper.loadQuery(mockresolver);
+    pageTestingHelper.loadQuery(mockResolver);
     pageTestingHelper.renderPage();
 
     userEvent.click(screen.queryByText("Discard Project Revision"));


### PR DESCRIPTION
issue #234

The Discard Changes button has been moved to the top & renamed / restyled
![Screenshot from 2022-05-12 15-38-13](https://user-images.githubusercontent.com/26367840/168178961-e9b50526-b0df-4839-8da9-cc4aff416c58.png)

Clicking the Discard Project Revision button replaces the button with a confirmation alert that allows you to proceed with the discard or cancel.
![Screenshot from 2022-05-12 15-38-31](https://user-images.githubusercontent.com/26367840/168179022-7094ad74-0c5d-42fc-9959-f95d9331016c.png)
