### PR TITLE
Chore/mock router

### DIFF
--- a/app/tests/helpers/componentTestingHelper.tsx
+++ b/app/tests/helpers/componentTestingHelper.tsx
@@ -12,6 +12,10 @@ import {
   OperationType,
 } from "relay-runtime";
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator";
+import { RouterContext } from "next/dist/shared/lib/router-context";
+import { NextRouter } from "next/router";
+import { createMockRouter } from "./mockNextRouter";
+jest.spyOn(require("next/router"), "useRouter");
 
 interface ComponentTestingHelperOptions<TQuery extends OperationType> {
   component: (props: any) => JSX.Element;
@@ -21,10 +25,13 @@ interface ComponentTestingHelperOptions<TQuery extends OperationType> {
   defaultQueryResolver?: MockResolvers;
   defaultQueryVariables?: TQuery["variables"];
   defaultComponentProps?: any;
+  routerOptions?: Partial<NextRouter>;
 }
 
 class ComponentTestingHelper<TQuery extends OperationType> {
   public environment: RelayMockEnvironment;
+
+  public router: NextRouter;
 
   public errorContext: {
     error: any;
@@ -55,6 +62,7 @@ class ComponentTestingHelper<TQuery extends OperationType> {
         })
       ),
     };
+    this.router = createMockRouter();
   }
 
   public loadQuery(queryResolver?: MockResolvers) {
@@ -97,12 +105,14 @@ class ComponentTestingHelper<TQuery extends OperationType> {
   ) {
     return render(
       <ErrorContext.Provider value={this.errorContext}>
-        <RelayEnvironmentProvider environment={this.environment}>
-          <this.TestRenderer
-            getPropsFromTestQuery={getPropsFromTestQuery}
-            extraProps={extraProps}
-          />
-        </RelayEnvironmentProvider>
+        <RouterContext.Provider value={this.router}>
+          <RelayEnvironmentProvider environment={this.environment}>
+            <this.TestRenderer
+              getPropsFromTestQuery={getPropsFromTestQuery}
+              extraProps={extraProps}
+            />
+          </RelayEnvironmentProvider>
+        </RouterContext.Provider>
       </ErrorContext.Provider>
     );
   }

--- a/app/tests/helpers/mockNextRouter.ts
+++ b/app/tests/helpers/mockNextRouter.ts
@@ -1,0 +1,11 @@
+import { mocked } from "jest-mock";
+import { NextRouter, useRouter } from "next/router";
+
+const createMockNextRouter = (routerOpts: Partial<NextRouter>) => {
+  const router = mocked(useRouter);
+  router.mockReturnValue({
+    ...routerOpts,
+  } as any);
+  return router;
+};
+export default createMockNextRouter;

--- a/app/tests/helpers/mockNextRouter.ts
+++ b/app/tests/helpers/mockNextRouter.ts
@@ -1,11 +1,31 @@
-import { mocked } from "jest-mock";
-import { NextRouter, useRouter } from "next/router";
+import { NextRouter } from "next/router";
 
-const createMockNextRouter = (routerOpts: Partial<NextRouter>) => {
-  const router = mocked(useRouter);
-  router.mockReturnValue({
-    ...routerOpts,
-  } as any);
-  return router;
-};
-export default createMockNextRouter;
+export function createMockRouter(
+  routerOptions?: Partial<NextRouter>
+): NextRouter {
+  return {
+    basePath: "",
+    pathname: "/",
+    route: "/",
+    query: {},
+    asPath: "/",
+    back: jest.fn(),
+    beforePopState: jest.fn(),
+    prefetch: jest.fn(),
+    push: jest.fn(),
+    reload: jest.fn(),
+    replace: jest.fn(),
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+    },
+    isFallback: false,
+    isLocaleDomain: false,
+    isReady: true,
+    defaultLocale: "en",
+    domainLocales: [],
+    isPreview: false,
+    ...routerOptions,
+  };
+}

--- a/app/tests/helpers/pageTestingHelper.tsx
+++ b/app/tests/helpers/pageTestingHelper.tsx
@@ -13,6 +13,8 @@ import {
 import { RelayProps } from "relay-nextjs";
 import { ConcreteRequest, OperationType } from "relay-runtime";
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator";
+import { RouterContext } from "next/dist/shared/lib/router-context";
+import createMockNextRouter from "./mockNextRouter";
 
 interface PageTestingHelperOptions<TQuery extends OperationType> {
   pageComponent: (props: RelayProps<{}, TQuery>) => JSX.Element;
@@ -85,6 +87,22 @@ class PageTestingHelper<TQuery extends OperationType> {
             preloadedQuery={this.initialQueryRef}
           />
         </RelayEnvironmentProvider>
+      </ErrorContext.Provider>
+    );
+  }
+
+  public renderPageWithMockRouter(routerOpts) {
+    const router = createMockNextRouter(routerOpts);
+    return render(
+      <ErrorContext.Provider value={this.errorContext}>
+        <RouterContext.Provider value={router as any}>
+          <RelayEnvironmentProvider environment={this.environment}>
+            <this.options.pageComponent
+              CSN
+              preloadedQuery={this.initialQueryRef}
+            />
+          </RelayEnvironmentProvider>
+        </RouterContext.Provider>
       </ErrorContext.Provider>
     );
   }

--- a/app/tests/helpers/pageTestingHelper.tsx
+++ b/app/tests/helpers/pageTestingHelper.tsx
@@ -14,8 +14,9 @@ import { RelayProps } from "relay-nextjs";
 import { ConcreteRequest, OperationType } from "relay-runtime";
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator";
 import { createMockRouter } from "./mockNextRouter";
-import { mocked } from "jest-mock";
-import { NextRouter, useRouter } from "next/router";
+import { NextRouter } from "next/router";
+import { RouterContext } from "next/dist/shared/lib/router-context";
+jest.spyOn(require("next/router"), "useRouter");
 
 interface PageTestingHelperOptions<TQuery extends OperationType> {
   pageComponent: (props: RelayProps<{}, TQuery>) => JSX.Element;
@@ -88,16 +89,16 @@ class PageTestingHelper<TQuery extends OperationType> {
   }
 
   public renderPage() {
-    mocked(useRouter).mockReturnValue(this.router);
-
     return render(
       <ErrorContext.Provider value={this.errorContext}>
-        <RelayEnvironmentProvider environment={this.environment}>
-          <this.options.pageComponent
-            CSN
-            preloadedQuery={this.initialQueryRef}
-          />
-        </RelayEnvironmentProvider>
+        <RouterContext.Provider value={this.router}>
+          <RelayEnvironmentProvider environment={this.environment}>
+            <this.options.pageComponent
+              CSN
+              preloadedQuery={this.initialQueryRef}
+            />
+          </RelayEnvironmentProvider>
+        </RouterContext.Provider>
       </ErrorContext.Provider>
     );
   }

--- a/app/tests/unit/components/Attachment/AttachmentTableRow.test.tsx
+++ b/app/tests/unit/components/Attachment/AttachmentTableRow.test.tsx
@@ -1,15 +1,11 @@
 import { screen } from "@testing-library/react";
 import AttachmentTableRow from "components/Attachment/AttachmentTableRow";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/dist/client/router";
 import { graphql } from "react-relay";
 import ComponentTestingHelper from "tests/helpers/componentTestingHelper";
 import compiledAttachmentTableRowTestQuery, {
   AttachmentTableRowTestQuery,
 } from "__generated__/AttachmentTableRowTestQuery.graphql";
 import { AttachmentTableRow_attachment } from "__generated__/AttachmentTableRow_attachment.graphql";
-
-jest.mock("next/dist/client/router");
 
 const testQuery = graphql`
   query AttachmentTableRowTestQuery @relay_test_operation {
@@ -59,15 +55,8 @@ const componentTestingHelper =
     getPropsFromTestQuery: (data) => ({ attachment: data.query.attachment }),
   });
 
-const routerPush = jest.fn();
-
 describe("The Attachment table row component", () => {
   beforeEach(() => {
-    jest.resetAllMocks();
-    mocked(useRouter).mockReturnValue({
-      push: routerPush,
-    } as any);
-
     componentTestingHelper.reinit();
   });
 
@@ -88,7 +77,7 @@ describe("The Attachment table row component", () => {
     const viewButton = screen.getByText("View");
     viewButton.click();
 
-    expect(routerPush).toHaveBeenCalledWith(
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       "/cif/attachments/[attachment]?attachment=Cif+Test+Attachment+ID",
       expect.anything(),
       expect.anything()
@@ -101,7 +90,7 @@ describe("The Attachment table row component", () => {
     const downloadButton = screen.getByText("Download");
     downloadButton.click();
 
-    expect(routerPush).toHaveBeenCalledWith(
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       "/download/Cif%20Test%20Attachment%20ID",
       expect.anything(),
       expect.anything()

--- a/app/tests/unit/components/Dashboard.test.tsx
+++ b/app/tests/unit/components/Dashboard.test.tsx
@@ -1,20 +1,12 @@
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Dashboard from "components/Dashboard";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { graphql } from "react-relay";
 import { MockPayloadGenerator } from "relay-test-utils";
 import ComponentTestingHelper from "tests/helpers/componentTestingHelper";
 import compiledDashboardTestQuery, {
   DashboardTestQuery,
 } from "__generated__/DashboardTestQuery.graphql";
-
-jest.mock("next/router");
-
-const routerPush = jest.fn();
-
-mocked(useRouter).mockReturnValue({ push: routerPush } as any);
 
 const testQuery = graphql`
   query DashboardTestQuery @relay_test_operation {
@@ -76,7 +68,7 @@ describe("The Dashboard", () => {
         MockPayloadGenerator.generate(operation)
       );
     });
-    expect(routerPush).toHaveBeenCalledWith({
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/overview/",
       query: { projectRevision: "<ProjectRevision-mock-id-1>" },
     });

--- a/app/tests/unit/components/Layout/DefaultLayout.test.tsx
+++ b/app/tests/unit/components/Layout/DefaultLayout.test.tsx
@@ -1,14 +1,10 @@
 import { screen } from "@testing-library/react";
 import DefaultLayout from "components/Layout/DefaultLayout";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { graphql } from "relay-runtime";
 import ComponentTestingHelper from "tests/helpers/componentTestingHelper";
 import compiledDefaultLayoutTestQuery, {
   DefaultLayoutTestQuery,
 } from "__generated__/DefaultLayoutTestQuery.graphql";
-jest.mock("next/router");
-mocked(useRouter).mockReturnValue({ query: {} } as any);
 
 const testQuery = graphql`
   query DefaultLayoutTestQuery @relay_test_operation {

--- a/app/tests/unit/components/TaskList.test.tsx
+++ b/app/tests/unit/components/TaskList.test.tsx
@@ -5,16 +5,6 @@ import ComponentTestingHelper from "tests/helpers/componentTestingHelper";
 import compiledTaskListQuery, {
   TaskListQuery,
 } from "__generated__/TaskListQuery.graphql";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
-
-jest.mock("next/dist/client/router");
-const mockPush = jest.fn();
-mocked(useRouter).mockImplementation(() => {
-  return {
-    push: mockPush,
-  } as any;
-});
 
 const testQuery = graphql`
   query TaskListQuery($projectRevision: ID!) @relay_test_operation {
@@ -112,7 +102,7 @@ describe("The ProjectManagerForm", () => {
     fireEvent.click(screen.getByText(/Project Overview/i));
     fireEvent.click(screen.getByText(/Edit project overview/i));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       "/cif/project-revision/[projectRevision]/form/overview?projectRevision=test-project-revision-id",
       "/cif/project-revision/test-project-revision-id/form/overview",
       expect.any(Object)
@@ -126,7 +116,7 @@ describe("The ProjectManagerForm", () => {
     fireEvent.click(screen.getByText(/Project Details/i));
     fireEvent.click(screen.getByText(/Edit project contacts/i));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       "/cif/project-revision/[projectRevision]/form/contacts?projectRevision=test-project-revision-id",
       "/cif/project-revision/test-project-revision-id/form/contacts",
       expect.any(Object)
@@ -139,7 +129,7 @@ describe("The ProjectManagerForm", () => {
     fireEvent.click(screen.getByText(/Project Details/i));
     fireEvent.click(screen.getByText(/Edit project managers/i));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       "/cif/project-revision/[projectRevision]/form/managers?projectRevision=test-project-revision-id",
       "/cif/project-revision/test-project-revision-id/form/managers",
       expect.any(Object)
@@ -153,7 +143,7 @@ describe("The ProjectManagerForm", () => {
     fireEvent.click(screen.getByText(/Quarterly Reports/i));
     fireEvent.click(screen.getByText(/Edit quarterly reports/i));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       "/cif/project-revision/[projectRevision]/form/quarterly-reports?projectRevision=test-project-revision-id",
       "/cif/project-revision/test-project-revision-id/form/quarterly-reports",
       expect.any(Object)

--- a/app/tests/unit/pages/contact/[contact].test.tsx
+++ b/app/tests/unit/pages/contact/[contact].test.tsx
@@ -1,14 +1,10 @@
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { ContactViewPage } from "pages/cif/contact/[contact]";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledContactViewQuery, {
   ContactViewQuery,
 } from "__generated__/ContactViewQuery.graphql";
-
-jest.mock("next/router");
 
 const defaultMockResolver = {
   Contact() {
@@ -44,9 +40,7 @@ describe("ContactViewPage", () => {
       require("app/hooks/useRedirectTo404IfFalsy"),
       "default"
     );
-    mocked(useRouter).mockReturnValue({
-      replace: jest.fn(),
-    } as any);
+
     pageTestingHelper.loadQuery({
       Query() {
         return {

--- a/app/tests/unit/pages/contacts.test.tsx
+++ b/app/tests/unit/pages/contacts.test.tsx
@@ -1,20 +1,11 @@
 import "@testing-library/jest-dom";
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledContactsQuery, {
   contactsQuery,
 } from "__generated__/contactsQuery.graphql";
 import { Contacts } from "../../../pages/cif/contacts";
-jest.mock("next/router");
-
-mocked(useRouter).mockReturnValue({
-  route: "/",
-  query: {},
-  push: jest.fn(),
-} as any);
 
 const defaultMockResolver = {
   Query() {

--- a/app/tests/unit/pages/operator/[operator].test.tsx
+++ b/app/tests/unit/pages/operator/[operator].test.tsx
@@ -1,14 +1,10 @@
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { OperatorViewPage } from "pages/cif/operator/[operator]";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledOperatorViewQuery, {
   OperatorViewQuery,
 } from "__generated__/OperatorViewQuery.graphql";
-
-jest.mock("next/router");
 
 const defaultMockResolver = {
   Operator() {
@@ -120,9 +116,7 @@ describe("OperatorViewPage", () => {
       require("app/hooks/useRedirectTo404IfFalsy"),
       "default"
     );
-    mocked(useRouter).mockReturnValue({
-      replace: jest.fn(),
-    } as any);
+
     pageTestingHelper.loadQuery({
       Query() {
         return {

--- a/app/tests/unit/pages/operators.test.tsx
+++ b/app/tests/unit/pages/operators.test.tsx
@@ -2,20 +2,11 @@ import "@testing-library/jest-dom";
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DEFAULT_PAGE_SIZE } from "components/Table/Pagination";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledOperatorsQuery, {
   operatorsQuery,
 } from "__generated__/operatorsQuery.graphql";
 import { Operators } from "../../../pages/cif/operators";
-jest.mock("next/router");
-
-mocked(useRouter).mockReturnValue({
-  route: "/",
-  query: {},
-  push: jest.fn(),
-} as any);
 
 const defaultMockResolver = {
   Query() {

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
@@ -1,8 +1,6 @@
 import "@testing-library/jest-dom";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { getProjectRevisionPageRoute } from "pageRoutes";
 import { ProjectContactsPage } from "pages/cif/project-revision/[projectRevision]/form/contacts";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
@@ -52,12 +50,11 @@ describe("The Project Contacts page", () => {
   });
 
   it("renders the task list in the left navigation with correct highlighting", () => {
-    const router = mocked(useRouter);
     const mockPathname =
       "/cif/project-revision/[projectRevision]/form/contacts";
-    router.mockReturnValue({
+    pageTestingHelper.setRouterOptions({
       pathname: mockPathname,
-    } as any);
+    });
 
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
@@ -280,12 +277,6 @@ describe("The Project Contacts page", () => {
   });
 
   it("redirects the user to the project revision page on submit", () => {
-    const router = mocked(useRouter);
-    const mockPush = jest.fn();
-    router.mockReturnValue({
-      push: mockPush,
-    } as any);
-
     let handleSubmit;
     jest
       .spyOn(require("components/Form/ProjectContactForm"), "default")
@@ -297,17 +288,12 @@ describe("The Project Contacts page", () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
     handleSubmit();
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith(
       getProjectRevisionPageRoute("mock-proj-rev-id")
     );
   });
 
   it("renders null and redirects to a 404 page when a revision doesn't exist", async () => {
-    const mockReplace = jest.fn();
-    mocked(useRouter).mockReturnValue({
-      replace: mockReplace,
-    } as any);
-
     pageTestingHelper.loadQuery({
       Query() {
         return {
@@ -319,14 +305,10 @@ describe("The Project Contacts page", () => {
     const { container } = pageTestingHelper.renderPage();
 
     expect(container.childElementCount).toEqual(0);
-    expect(mockReplace).toHaveBeenCalledWith("/404");
+    expect(pageTestingHelper.router.replace).toHaveBeenCalledWith("/404");
   });
 
   it("renders the form in view mode when the project revision is committed", async () => {
-    jest.mock("next/router");
-    const routerPush = jest.fn();
-    mocked(useRouter).mockReturnValue({ push: routerPush } as any);
-
     pageTestingHelper.loadQuery({
       ProjectRevision(context) {
         const revision = {
@@ -451,7 +433,7 @@ describe("The Project Contacts page", () => {
     ).toHaveTextContent("Test Secondary");
 
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
-    expect(routerPush).toHaveBeenCalledWith({
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/contacts/",
       query: { projectRevision: "mock-pending-revision-id" },
     });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/contacts.test.tsx
@@ -9,8 +9,6 @@ import compiledContactsFormQuery, {
 } from "__generated__/contactsFormQuery.graphql";
 import { ProjectContactForm_query$data } from "__generated__/ProjectContactForm_query.graphql";
 
-jest.mock("next/router");
-
 /***
  * https://relay.dev/docs/next/guides/testing-relay-with-preloaded-queries/#configure-the-query-resolver-to-generate-the-response
  * To find the key of the generated operation, one can call

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/managers.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/managers.test.tsx
@@ -53,8 +53,9 @@ describe("The Project Managers form page", () => {
   it("renders the task list in the left navigation", () => {
     const mockPathname =
       "/cif/project-revision/[projectRevision]/form/managers";
+    pageTestingHelper.setRouterOptions({ pathname: mockPathname });
     pageTestingHelper.loadQuery();
-    pageTestingHelper.renderPageWithMockRouter({ pathname: mockPathname });
+    pageTestingHelper.renderPage();
     expect(
       within(
         screen.getByRole("navigation", { name: "side navigation" })
@@ -315,10 +316,9 @@ describe("The Project Managers form page", () => {
       });
 
     pageTestingHelper.loadQuery();
-    const mockPush = jest.fn();
-    pageTestingHelper.renderPageWithMockRouter({ push: mockPush });
+    pageTestingHelper.renderPage();
     handleSubmit();
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith(
       getProjectRevisionPageRoute("mock-proj-rev-2")
     );
   });
@@ -332,13 +332,10 @@ describe("The Project Managers form page", () => {
       },
     });
 
-    const mockReplace = jest.fn();
-    const { container } = pageTestingHelper.renderPageWithMockRouter({
-      replace: mockReplace,
-    });
+    const { container } = pageTestingHelper.renderPage();
 
     expect(container.childElementCount).toEqual(0);
-    expect(mockReplace).toHaveBeenCalledWith("/404");
+    expect(pageTestingHelper.router.replace).toHaveBeenCalledWith("/404");
   });
 
   it("renders the form in view mode when the project revision is committed", async () => {
@@ -420,8 +417,7 @@ describe("The Project Managers form page", () => {
       },
     });
 
-    const mockPush = jest.fn();
-    pageTestingHelper.renderPageWithMockRouter({ push: mockPush });
+    pageTestingHelper.renderPage();
 
     expect(
       screen.queryByRole("button", { name: "submit" })
@@ -436,7 +432,7 @@ describe("The Project Managers form page", () => {
       "test manager 3"
     );
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
-    expect(mockPush).toHaveBeenCalledWith({
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/managers/",
       query: { projectRevision: "mock-pending-revision-id" },
     });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/managers.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/managers.test.tsx
@@ -9,8 +9,6 @@ import compiledManagersFormQuery, {
 } from "__generated__/managersFormQuery.graphql";
 import { ProjectManagerForm_query$data } from "__generated__/ProjectManagerForm_query.graphql";
 
-jest.mock("next/router");
-
 /***
  * https://relay.dev/docs/next/guides/testing-relay-with-preloaded-queries/#configure-the-query-resolver-to-generate-the-response
  * To find the key of the generated operation, one can call

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
@@ -1,8 +1,6 @@
 import "@testing-library/jest-dom";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { getProjectRevisionPageRoute } from "pageRoutes";
 import { ProjectOverviewForm } from "pages/cif/project-revision/[projectRevision]/form/overview";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
@@ -53,12 +51,11 @@ describe("The Project Overview page", () => {
   });
 
   it("renders the task list in the left navigation", () => {
-    const router = mocked(useRouter);
     const mockPathname =
       "/cif/project-revision/[projectRevision]/form/overview";
-    router.mockReturnValue({
+    pageTestingHelper.setRouterOptions({
       pathname: mockPathname,
-    } as any);
+    });
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
     expect(
@@ -278,12 +275,6 @@ describe("The Project Overview page", () => {
   });
 
   it("redirects the user to the project revision page on submit", () => {
-    const router = mocked(useRouter);
-    const mockPush = jest.fn();
-    router.mockReturnValue({
-      push: mockPush,
-    } as any);
-
     let handleSubmit;
     jest
       .spyOn(require("components/Form/ProjectForm"), "default")
@@ -295,17 +286,12 @@ describe("The Project Overview page", () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
     handleSubmit();
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith(
       getProjectRevisionPageRoute("mock-proj-rev-id")
     );
   });
 
   it("renders null and redirects to a 404 page when a revision doesn't exist", async () => {
-    const mockReplace = jest.fn();
-    mocked(useRouter).mockReturnValue({
-      replace: mockReplace,
-    } as any);
-
     pageTestingHelper.loadQuery({
       Query() {
         return {
@@ -317,14 +303,10 @@ describe("The Project Overview page", () => {
     const { container } = pageTestingHelper.renderPage();
 
     expect(container.childElementCount).toEqual(0);
-    expect(mockReplace).toHaveBeenCalledWith("/404");
+    expect(pageTestingHelper.router.replace).toHaveBeenCalledWith("/404");
   });
 
   it("renders the form in view mode when the project revision is committed", () => {
-    jest.mock("next/router");
-    const routerPush = jest.fn();
-    mocked(useRouter).mockReturnValue({ push: routerPush } as any);
-
     pageTestingHelper.loadQuery({
       ProjectRevision(context) {
         return {
@@ -439,7 +421,7 @@ describe("The Project Overview page", () => {
     ).toHaveTextContent("$25.00");
 
     userEvent.click(screen.getByRole("button", { name: /resume edition/i }));
-    expect(routerPush).toHaveBeenCalledWith({
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/form/overview/",
       query: { projectRevision: "mock-pending-revision-id" },
     });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/overview.test.tsx
@@ -10,8 +10,6 @@ import compiledOverviewFormQuery, {
 import { ProjectForm_projectRevision$data } from "__generated__/ProjectForm_projectRevision.graphql";
 import { SelectRfpWidget_query$data } from "__generated__/SelectRfpWidget_query.graphql";
 
-jest.mock("next/router");
-
 /***
  * https://relay.dev/docs/next/guides/testing-relay-with-preloaded-queries/#configure-the-query-resolver-to-generate-the-response
  * To find the key of the generated operation, one can call

--- a/app/tests/unit/pages/project-revision/[projectRevision]/form/quarterly-reports.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/form/quarterly-reports.test.tsx
@@ -1,15 +1,11 @@
 import "@testing-library/jest-dom";
 import { screen, within } from "@testing-library/react";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { getProjectRevisionPageRoute } from "pageRoutes";
 import { ProjectQuarterlyReportsPage } from "pages/cif/project-revision/[projectRevision]/form/quarterly-reports";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledQuarterlyReportsFormQuery, {
   quarterlyReportsFormQuery,
 } from "__generated__/quarterlyReportsFormQuery.graphql";
-
-jest.mock("next/dist/client/router");
 
 /***
  * https://relay.dev/docs/next/guides/testing-relay-with-preloaded-queries/#configure-the-query-resolver-to-generate-the-response
@@ -50,12 +46,11 @@ describe("The Project Quarterly Reports page", () => {
   });
 
   it("renders the task list in the left navigation with correct highlighting", () => {
-    const router = mocked(useRouter);
     const mockPathname =
       "/cif/project-revision/[projectRevision]/form/quarterly-reports";
-    router.mockReturnValue({
+    pageTestingHelper.setRouterOptions({
       pathname: mockPathname,
-    } as any);
+    });
 
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
@@ -71,12 +66,6 @@ describe("The Project Quarterly Reports page", () => {
   });
 
   it("redirects the user to the project revision page on submit", () => {
-    const router = mocked(useRouter);
-    const mockPush = jest.fn();
-    router.mockReturnValue({
-      push: mockPush,
-    } as any);
-
     let handleSubmit;
     jest
       .spyOn(require("components/Form/ProjectQuarterlyReportForm"), "default")
@@ -87,17 +76,12 @@ describe("The Project Quarterly Reports page", () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
     handleSubmit();
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith(
       getProjectRevisionPageRoute("mock-proj-rev-2")
     );
   });
 
   it("renders null and redirects to a 404 page when a revision doesn't exist", async () => {
-    const mockReplace = jest.fn();
-    mocked(useRouter).mockReturnValue({
-      replace: mockReplace,
-    } as any);
-
     pageTestingHelper.loadQuery({
       Query() {
         return {
@@ -109,6 +93,6 @@ describe("The Project Quarterly Reports page", () => {
     const { container } = pageTestingHelper.renderPage();
 
     expect(container.childElementCount).toEqual(0);
-    expect(mockReplace).toHaveBeenCalledWith("/404");
+    expect(pageTestingHelper.router.replace).toHaveBeenCalledWith("/404");
   });
 });

--- a/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
@@ -7,8 +7,6 @@ import compiledProjectRevisionQuery, {
   ProjectRevisionQuery,
 } from "__generated__/ProjectRevisionQuery.graphql";
 
-jest.mock("next/router");
-
 /***
  * https://relay.dev/docs/next/guides/testing-relay-with-preloaded-queries/#configure-the-query-resolver-to-generate-the-response
  * To find the key of the generated operation, one can call

--- a/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
@@ -1,8 +1,6 @@
 import "@testing-library/jest-dom";
 import { act, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { ProjectRevision } from "pages/cif/project-revision/[projectRevision]";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledProjectRevisionQuery, {
@@ -49,11 +47,10 @@ describe("The Create Project page", () => {
   });
 
   it("renders the task list in the left navigation with correct highlighting", () => {
-    const router = mocked(useRouter);
     const mockPathname = "/cif/project-revision/[projectRevision]";
-    router.mockReturnValue({
+    pageTestingHelper.setRouterOptions({
       pathname: mockPathname,
-    } as any);
+    });
 
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
@@ -272,10 +269,6 @@ describe("The Create Project page", () => {
       .spyOn(require("mutations/useMutationWithErrorMessage"), "default")
       .mockImplementation(() => [useMutationSpy, false]);
 
-    jest.spyOn(require("next/router"), "useRouter").mockImplementation(() => {
-      return { push: jest.fn() };
-    });
-
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
 
@@ -367,9 +360,6 @@ describe("The Create Project page", () => {
       "default"
     );
 
-    mocked(useRouter).mockReturnValue({
-      replace: jest.fn(),
-    } as any);
     pageTestingHelper.loadQuery({
       Query() {
         return {
@@ -436,11 +426,6 @@ describe("The Create Project page", () => {
   });
 
   it("routes to the project list page when discarding a project revision and isFirstRevision is true", () => {
-    mocked(useRouter).mockReturnValue({
-      replace: jest.fn(),
-      push: jest.fn(),
-    } as any);
-
     const mockResolver = {
       ProjectRevision() {
         return {
@@ -460,17 +445,12 @@ describe("The Create Project page", () => {
       });
     });
 
-    expect(useRouter().push).toHaveBeenCalledWith({
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith({
       pathname: "/cif/projects/",
     });
   });
 
   it("routes to the project overview when discarding project revision and isFirstRevision is false", () => {
-    mocked(useRouter).mockReturnValue({
-      replace: jest.fn(),
-      push: jest.fn(),
-    } as any);
-
     const mockResolver = {
       ProjectRevision() {
         return {
@@ -496,7 +476,7 @@ describe("The Create Project page", () => {
       });
     });
 
-    expect(useRouter().push).toHaveBeenCalledWith({
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith({
       pathname: "/cif/project-revision/[projectRevision]/",
       query: {
         projectRevision: "mock-proj-rev-id",

--- a/app/tests/unit/pages/project/[project].test.tsx
+++ b/app/tests/unit/pages/project/[project].test.tsx
@@ -3,12 +3,8 @@ import { screen, act } from "@testing-library/react";
 import compiledProjectOverviewQuery, {
   ProjectOverviewQuery,
 } from "__generated__/ProjectOverviewQuery.graphql";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import userEvent from "@testing-library/user-event";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
-
-jest.mock("next/router");
 
 const defaultMockResolver = {
   Project() {
@@ -218,9 +214,6 @@ describe("ProjectViewPage", () => {
       require("app/hooks/useRedirectTo404IfFalsy"),
       "default"
     );
-    mocked(useRouter).mockReturnValue({
-      replace: jest.fn(),
-    } as any);
     pageTestingHelper.loadQuery({
       Query() {
         return {

--- a/app/tests/unit/pages/project/attachments.test.tsx
+++ b/app/tests/unit/pages/project/attachments.test.tsx
@@ -5,8 +5,6 @@ import compiledAttachmentsQuery, {
   attachmentsQuery,
 } from "__generated__/attachmentsQuery.graphql";
 
-jest.mock("next/dist/client/router");
-
 const defaultQueryResolver = {
   Query() {
     return {

--- a/app/tests/unit/pages/project/attachments.test.tsx
+++ b/app/tests/unit/pages/project/attachments.test.tsx
@@ -1,6 +1,4 @@
 import { screen } from "@testing-library/react";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import { ProjectAttachments } from "pages/cif/project/[project]/attachments";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledAttachmentsQuery, {
@@ -48,10 +46,6 @@ describe("The project's attachment page", () => {
     pageTestingHelper.reinit();
   });
   it("renders a table with all the attachments", () => {
-    mocked(useRouter).mockReturnValue({
-      query: {},
-    } as any);
-
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
 
@@ -59,17 +53,11 @@ describe("The project's attachment page", () => {
     expect(screen.getAllByRole("row")).toHaveLength(5);
   });
   it("has a button to upload an attachment", () => {
-    const mockPush = jest.fn();
-    mocked(useRouter).mockReturnValue({
-      query: {},
-      push: mockPush,
-    } as any);
-
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
     screen.getByText("Upload New Attachment").click();
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(pageTestingHelper.router.push).toHaveBeenCalledWith(
       "/cif/project/[project]/upload-attachment?project=test-cif-project",
       expect.anything(),
       expect.anything()

--- a/app/tests/unit/pages/project/upload-attachment.test.tsx
+++ b/app/tests/unit/pages/project/upload-attachment.test.tsx
@@ -6,6 +6,8 @@ import compiledUploadAttachmentQuery, {
   uploadAttachmentQuery,
 } from "__generated__/uploadAttachmentQuery.graphql";
 
+jest.mock("next/router");
+
 const defaultQueryResolver = {
   Query() {
     return {

--- a/app/tests/unit/pages/projects.test.tsx
+++ b/app/tests/unit/pages/projects.test.tsx
@@ -2,20 +2,11 @@ import "@testing-library/jest-dom";
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DEFAULT_PAGE_SIZE } from "components/Table/Pagination";
-import { mocked } from "jest-mock";
-import { useRouter } from "next/router";
 import PageTestingHelper from "tests/helpers/pageTestingHelper";
 import compiledProjectsQuery, {
   projectsQuery,
 } from "__generated__/projectsQuery.graphql";
 import { Projects } from "../../../pages/cif/projects";
-jest.mock("next/router");
-
-mocked(useRouter).mockReturnValue({
-  route: "/",
-  query: {},
-  push: jest.fn(),
-} as any);
 
 const defaultMockResolver = {
   Query() {


### PR DESCRIPTION
This PR addresses the issue of repeatedly mocking the `NextRouter` in our test files.

Added a helper function `createMockRouter` which returns a Next Router, with all values mocked. (Functions are mocked with a `jest.fn()`.)

Example usage:
```javascript
    expect(pageTestingHelper.router.push).toHaveBeenCalledWith(
      getProjectRevisionPageRoute("mock-proj-rev-id")
    );
```
```javascript
const mockPathname = "/cif/project-revision/[projectRevision]/form/overview";
pageTestingHelper.setRouterOptions({ pathname: mockPathname });
```
