### PR TITLE
chore: placeholder functions for pages with no view component

### DIFF
--- a/app/data/formPages.tsx
+++ b/app/data/formPages.tsx
@@ -40,13 +40,13 @@ const formPages: FormPageDefinition[] = [
     title: "quarterly reports",
     editComponent: ProjectQuarterlyReportForm,
     // TODO: switch to ProjectQuarterlyReportFormSummary when it's been merged
-    viewComponent: null,
+    viewComponent: () => null,
   },
   {
     title: "annual reports",
     editComponent: ProjectAnnualReportForm,
     // TODO: switch to ProjectAnnualReportFormSummary when it's been merged
-    viewComponent: null,
+    viewComponent: () => null,
   },
 ];
 

--- a/app/pages/cif/project-revision/[projectRevision]/form/[formIndex]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/[formIndex]/index.tsx
@@ -153,7 +153,7 @@ export function ProjectFormPage({
   const ViewComponent = formPages[formIndex].viewComponent;
   return (
     <DefaultLayout session={query.session} leftSideNav={taskList}>
-      {query.projectRevision.changeStatus === "committed" && ViewComponent ? (
+      {query.projectRevision.changeStatus === "committed" ? (
         <>
           {createEditButton()}
           <ViewComponent


### PR DESCRIPTION
Render null in view mode for pages with no view component yet. Avoids having a fillable form that submitting does nothing.

ViewComponents will be added soon.