### PR TITLE
chore: increment cpanfile version requirements

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,3 @@
-requires 'DBD::Pg', '== 3.15.0';
-requires 'App::Sqitch', '== 1.1.0';
+requires 'DBD::Pg', '== 3.15.1';
+requires 'App::Sqitch', '== 1.2.1';
 requires 'TAP::Parser::SourceHandler::pgTAP', '== 3.35';


### PR DESCRIPTION
the docker build schema job was failing, getting invalid versions of DBD::Pg and Sqitch. Updating to the latest versions fixes it