### PR TITLE
Feat: Next due date in project list

### DIFF
--- a/app/components/Project/ProjectMilestoneDue.tsx
+++ b/app/components/Project/ProjectMilestoneDue.tsx
@@ -59,7 +59,7 @@ const ProjectMilestoneDue: React.FC<Props> = ({ project }) => {
     DateTime.fromISO(nextReportDueDate, {
       setZone: true,
       locale: "en-CA",
-    });
+    }).startOf("day");
 
   const reportDueIn =
     parsedNextReportDueDate &&

--- a/app/components/Project/ProjectMilestoneDue.tsx
+++ b/app/components/Project/ProjectMilestoneDue.tsx
@@ -1,0 +1,90 @@
+import Badge from "components/StatusBadge";
+import { DateTime } from "luxon";
+import { useFragment, graphql } from "react-relay";
+import { ProjectMilestoneDue_project$key } from "__generated__/ProjectMilestoneDue_project.graphql";
+
+interface Props {
+  project: ProjectMilestoneDue_project$key;
+}
+
+const ProjectMilestoneDue: React.FC<Props> = ({ project }) => {
+  const {
+    latestCommittedProjectRevision,
+    latestCompletedReportingRequirements,
+  } = useFragment(
+    graphql`
+      fragment ProjectMilestoneDue_project on Project {
+        latestCommittedProjectRevision {
+          upcomingReportingRequirementFormChange {
+            asReportingRequirement {
+              reportDueDate
+            }
+          }
+        }
+        latestCompletedReportingRequirements: reportingRequirementsByProjectId(
+          orderBy: REPORT_DUE_DATE_ASC
+          filter: { submittedDate: { isNull: false } }
+          first: 1
+        ) {
+          edges {
+            node {
+              reportDueDate
+            }
+          }
+        }
+      }
+    `,
+    project
+  );
+
+  const upcomingReportDueDate =
+    latestCommittedProjectRevision.upcomingReportingRequirementFormChange
+      ?.asReportingRequirement?.reportDueDate;
+  const latestCompletedReportDueDate =
+    latestCompletedReportingRequirements.edges[0]?.node?.reportDueDate;
+
+  const nextReportDueDate =
+    upcomingReportDueDate || latestCompletedReportDueDate;
+
+  if (!nextReportDueDate) {
+    return (
+      <>
+        <Badge variant="none" />
+      </>
+    );
+  }
+
+  const parsedNextReportDueDate =
+    nextReportDueDate &&
+    DateTime.fromISO(nextReportDueDate, {
+      setZone: true,
+      locale: "en-CA",
+    });
+
+  const reportDueIn =
+    parsedNextReportDueDate &&
+    parsedNextReportDueDate.diff(
+      // Current date without time information
+      DateTime.now().setZone("America/Vancouver").startOf("day"),
+      "days"
+    ).days;
+
+  return (
+    <>
+      {parsedNextReportDueDate && (
+        <div>{parsedNextReportDueDate.toFormat("MMM dd, yyyy")}</div>
+      )}
+      <Badge
+        variant={
+          upcomingReportDueDate
+            ? reportDueIn < 0
+              ? "late"
+              : "onTrack"
+            : "complete"
+        }
+      />
+    </>
+  );
+};
+
+export default ProjectMilestoneDue;

--- a/app/components/Project/ProjectTableRow.tsx
+++ b/app/components/Project/ProjectTableRow.tsx
@@ -4,21 +4,14 @@ import { getProjectRevisionFormPageRoute } from "pageRoutes";
 import { useFragment, graphql } from "react-relay";
 import { ProjectTableRow_project$key } from "__generated__/ProjectTableRow_project.graphql";
 import Money from "lib/helpers/Money";
+import ProjectMilestoneDue from "./ProjectMilestoneDue";
 
 interface Props {
   project: ProjectTableRow_project$key;
 }
 
 const ProjectTableRow: React.FC<Props> = ({ project }) => {
-  const {
-    projectName,
-    proposalReference,
-    projectStatusByProjectStatusId: { name },
-    totalFundingRequest,
-    operatorByOperatorId: { tradeName },
-    projectManagersByProjectId,
-    latestCommittedProjectRevision,
-  } = useFragment(
+  const projectData = useFragment(
     graphql`
       fragment ProjectTableRow_project on Project {
         id
@@ -44,10 +37,21 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
         latestCommittedProjectRevision {
           id
         }
+        ...ProjectMilestoneDue_project
       }
     `,
     project
   );
+
+  const {
+    projectName,
+    proposalReference,
+    projectStatusByProjectStatusId: { name },
+    totalFundingRequest,
+    operatorByOperatorId: { tradeName },
+    projectManagersByProjectId,
+    latestCommittedProjectRevision,
+  } = projectData;
 
   const router = useRouter();
 
@@ -64,6 +68,9 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
       <td className="proposal-reference">{proposalReference}</td>
       <td className="status-container">
         <span className="status-badge">{name}</span>
+      </td>
+      <td className="milestone-due">
+        <ProjectMilestoneDue project={projectData} />
       </td>
       <td>
         {projectManagersByProjectId.edges.map((manager, index) => {
@@ -111,7 +118,6 @@ const ProjectTableRow: React.FC<Props> = ({ project }) => {
           display: inline-block;
           white-space: nowrap;
         }
-
         .actions {
           display: flex;
           justify-content: space-around;

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -7,13 +7,13 @@ interface Props {
 
 const colours = {
   complete: {
-    labelColour: "#2E8540",
-    badgeColour: "rgba(47, 132, 64, 0.1)",
+    labelColour: "#236631",
+    badgeColour: "#EAF3EC",
     label: "Complete",
   },
   late: {
-    labelColour: "#D9292F",
-    badgeColour: "rgba(217, 41, 47, 0.1)",
+    labelColour: "#CC242A",
+    badgeColour: "#FBEAEA",
     label: "Late",
   },
   onTrack: {
@@ -22,18 +22,18 @@ const colours = {
     label: "On track",
   },
   none: {
-    labelColour: "#767676",
-    badgeColour: "rgba(156, 156, 156, 0.1)",
+    labelColour: "#666666",
+    badgeColour: "#E8E8E8",
     label: "None",
   },
   inReview: {
     labelColour: "#003366",
-    badgeColour: "rgba(0, 51, 102, 0.1)",
+    badgeColour: "#E6EBF0",
     label: "In review",
   },
   customText: {
-    labelColour: "#003366",
-    badgeColour: "rgba(0, 51, 102, 0.1)",
+    labelColour: "#666666",
+    badgeColour: "#E8E8E8",
   },
 };
 

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -54,13 +54,6 @@ const StatusBadge: React.FC<Props> = ({ label = "custom text", variant }) => {
           },
         }}
       />
-      <style jsx>
-        {`
-          .MuiChip-label {
-            color: pink;
-          }
-        `}
-      </style>
     </>
   );
 };

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -1,0 +1,68 @@
+import { Chip } from "@mui/material";
+
+interface Props {
+  label?: string;
+  variant: "complete" | "late" | "onTrack" | "inReview" | "customText" | "none";
+}
+
+const colours = {
+  complete: {
+    labelColour: "#2E8540",
+    badgeColour: "rgba(47, 132, 64, 0.1)",
+    label: "Complete",
+  },
+  late: {
+    labelColour: "#D9292F",
+    badgeColour: "rgba(217, 41, 47, 0.1)",
+    label: "Late",
+  },
+  onTrack: {
+    labelColour: "#FFFFFF",
+    badgeColour: "#003366",
+    label: "On track",
+  },
+  none: {
+    labelColour: "#767676",
+    badgeColour: "rgba(156, 156, 156, 0.1)",
+    label: "None",
+  },
+  inReview: {
+    labelColour: "#003366",
+    badgeColour: "rgba(0, 51, 102, 0.1)",
+    label: "In review",
+  },
+  customText: {
+    labelColour: "#003366",
+    badgeColour: "rgba(0, 51, 102, 0.1)",
+  },
+};
+
+const StatusBadge: React.FC<Props> = ({ label = "custom text", variant }) => {
+  return (
+    <>
+      <Chip
+        label={variant === "customText" ? label : colours[variant].label}
+        sx={{
+          backgroundColor: colours[variant].badgeColour,
+          ".MuiChip-label": {
+            color: colours[variant].labelColour,
+            marginLeft: "6px",
+            marginRight: "6px",
+            marginTop: "12px",
+            marginBottom: "12px",
+            fontWeight: "bold",
+          },
+        }}
+      />
+      <style jsx>
+        {`
+          .MuiChip-label {
+            color: pink;
+          }
+        `}
+      </style>
+    </>
+  );
+};
+
+export default StatusBadge;

--- a/app/pages/cif/projects.tsx
+++ b/app/pages/cif/projects.tsx
@@ -14,6 +14,7 @@ import {
   SortOnlyFilter,
   TextFilter,
   SearchableDropdownFilter,
+  DisplayOnlyFilter,
 } from "components/Table/Filters";
 import { useMemo } from "react";
 
@@ -106,6 +107,7 @@ export function Projects({ preloadedQuery }: RelayProps<{}, projectsQuery>) {
         allProjectStatuses.edges.map((e) => e.node.name),
         { orderByPrefix: "PROJECT_STATUS_BY_PROJECT_STATUS_ID__NAME" }
       ),
+      new DisplayOnlyFilter("Milestone Due"),
       new SearchableDropdownFilter(
         "Project Managers",
         "projectManagers",

--- a/app/tests/unit/components/Project/ProjectMilestoneDue.test.tsx
+++ b/app/tests/unit/components/Project/ProjectMilestoneDue.test.tsx
@@ -1,0 +1,147 @@
+import { screen } from "@testing-library/react";
+import ProjectMilestoneDue from "components/Project/ProjectMilestoneDue";
+import { graphql } from "react-relay";
+import ComponentTestingHelper from "tests/helpers/componentTestingHelper";
+import compliledProjectMilestoneDueQuery, {
+  ProjectMilestoneDueQuery,
+} from "__generated__/ProjectMilestoneDueQuery.graphql";
+
+const testQuery = graphql`
+  query ProjectMilestoneDueQuery($project: ID!) @relay_test_operation {
+    query {
+      project(id: $project) {
+        ...ProjectMilestoneDue_project
+      }
+    }
+  }
+`;
+
+const mockQueryPayload = {
+  Project() {
+    return {
+      latestCommittedProjectRevision: {
+        upcomingReportingRequirementFormChange: {
+          asReportingRequirement: {
+            reportDueDate: "2020-01-01",
+          },
+        },
+      },
+      latestCompletedReportingRequirements: {
+        edges: [
+          {
+            node: {
+              reportDueDate: "2020-01-02",
+            },
+          },
+        ],
+      },
+    };
+  },
+};
+
+const componentTestingHelper =
+  new ComponentTestingHelper<ProjectMilestoneDueQuery>({
+    component: ProjectMilestoneDue,
+    compiledQuery: compliledProjectMilestoneDueQuery,
+    testQuery: testQuery,
+    defaultQueryResolver: mockQueryPayload,
+    getPropsFromTestQuery: (data) => ({ project: data.query.project }),
+  });
+
+describe("The Project Milestone Due component", () => {
+  beforeEach(() => {
+    componentTestingHelper.reinit();
+  });
+
+  it("Displays 'none' if there are no requirements completed nor upcoming", () => {
+    componentTestingHelper.loadQuery({
+      Project() {
+        return {
+          latestCommittedProjectRevision: {
+            upcomingReportingRequirementFormChange: null,
+          },
+          latestCompletedReportingRequirements: {
+            edges: [],
+          },
+        };
+      },
+    });
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
+  it("Displays 'Complete' if there are no upcoming reporting requirements, and completed reporting requirements", () => {
+    componentTestingHelper.loadQuery({
+      Project() {
+        return {
+          latestCommittedProjectRevision: {
+            upcomingReportingRequirementFormChange: null,
+          },
+          latestCompletedReportingRequirements: {
+            edges: [
+              {
+                node: {
+                  reportDueDate: "2020-01-02",
+                },
+              },
+            ],
+          },
+        };
+      },
+    });
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByText("Complete")).toBeInTheDocument();
+  });
+
+  it("Displays 'Late' if the next upcoming requirement is overdue", () => {
+    componentTestingHelper.loadQuery({
+      Project() {
+        return {
+          latestCommittedProjectRevision: {
+            upcomingReportingRequirementFormChange: {
+              asReportingRequirement: {
+                reportDueDate: "2020-01-01",
+              },
+            },
+          },
+          latestCompletedReportingRequirements: {
+            edges: [
+              {
+                node: {
+                  reportDueDate: "2070-01-02",
+                },
+              },
+            ],
+          },
+        };
+      },
+    });
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByText("Late")).toBeInTheDocument();
+  });
+
+  it("Displays 'On track' if the next upcoming requirement is not due yet", () => {
+    componentTestingHelper.loadQuery({
+      Project() {
+        return {
+          latestCommittedProjectRevision: {
+            upcomingReportingRequirementFormChange: {
+              asReportingRequirement: {
+                reportDueDate: "2080-01-01",
+              },
+            },
+          },
+          latestCompletedReportingRequirements: {
+            edges: [],
+          },
+        };
+      },
+    });
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByText("On track")).toBeInTheDocument();
+  });
+});

--- a/app/tests/unit/components/Project/ProjectMilestoneDue.test.tsx
+++ b/app/tests/unit/components/Project/ProjectMilestoneDue.test.tsx
@@ -16,35 +16,12 @@ const testQuery = graphql`
   }
 `;
 
-const mockQueryPayload = {
-  Project() {
-    return {
-      latestCommittedProjectRevision: {
-        upcomingReportingRequirementFormChange: {
-          asReportingRequirement: {
-            reportDueDate: "2020-01-01",
-          },
-        },
-      },
-      latestCompletedReportingRequirements: {
-        edges: [
-          {
-            node: {
-              reportDueDate: "2020-01-02",
-            },
-          },
-        ],
-      },
-    };
-  },
-};
-
 const componentTestingHelper =
   new ComponentTestingHelper<ProjectMilestoneDueQuery>({
     component: ProjectMilestoneDue,
     compiledQuery: compliledProjectMilestoneDueQuery,
     testQuery: testQuery,
-    defaultQueryResolver: mockQueryPayload,
+    defaultQueryResolver: {},
     getPropsFromTestQuery: (data) => ({ project: data.query.project }),
   });
 

--- a/app/tests/unit/components/StatusBadge.test.tsx
+++ b/app/tests/unit/components/StatusBadge.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import StatusBadge from "components/StatusBadge";
+
+describe("The Status Badge", () => {
+  it("displays the proper status when the variant is set", () => {
+    render(<StatusBadge variant="complete" />);
+    expect(screen.getByText("Complete")).toBeInTheDocument();
+    cleanup();
+
+    render(<StatusBadge variant="late" />);
+    expect(screen.getByText("Late")).toBeInTheDocument();
+    cleanup();
+
+    render(<StatusBadge variant="onTrack" />);
+    expect(screen.getByText("On track")).toBeInTheDocument();
+    cleanup();
+
+    render(<StatusBadge variant="none" />);
+    expect(screen.getByText("None")).toBeInTheDocument();
+    cleanup();
+
+    render(<StatusBadge variant="inReview" />);
+    expect(screen.getByText("In review")).toBeInTheDocument();
+    cleanup();
+  });
+
+  it("displays the custom text when the variant is set to customText", () => {
+    render(<StatusBadge variant="customText" label="Some Test Label" />);
+    expect(screen.getByText("Some Test Label")).toBeInTheDocument();
+  });
+
+  it("doesnt display the optional label when the variant is not customText", () => {
+    render(<StatusBadge variant="none" label="Some Test Label" />);
+    expect(screen.queryByText("Some Test Label")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adding the next due date in the project list, including a `None` indicator that was in the Figma wireframes

![image](https://user-images.githubusercontent.com/11507754/171967756-51ed0b5e-fdd2-408e-b77b-c973ed4e2abe.png)
