### PR TITLE
Fix: Due date indicator off by one day

### DIFF
--- a/app/components/ReportingRequirement/ReportDueIndicator.tsx
+++ b/app/components/ReportingRequirement/ReportDueIndicator.tsx
@@ -44,11 +44,13 @@ const ReportDueIndicator: React.FC<Props> = ({
     DateTime.fromISO(reportingRequirement.reportDueDate, {
       setZone: true,
       locale: "en-CA",
-    }).diff(
-      // Current date without time information
-      DateTime.now().setZone("America/Vancouver").startOf("day"),
-      "days"
-    );
+    })
+      .startOf("day")
+      .diff(
+        // Current date without time information
+        DateTime.now().setZone("America/Vancouver").startOf("day"),
+        "days"
+      );
 
   const overdue = reportDueIn?.days < 0;
 
@@ -94,7 +96,7 @@ const ReportDueIndicator: React.FC<Props> = ({
                 {hasValidReportDueDate ? (
                   <>
                     {overdue ? "Overdue by " : "Due in "}
-                    <b>{Math.floor(Math.abs(reportDueIn.days))} day(s)</b>
+                    <b>{Math.abs(reportDueIn.days)} day(s)</b>
                   </>
                 ) : (
                   "-"


### PR DESCRIPTION
Fixing inconsistent date handling in the report due date indicator
<img width="196" alt="image" src="https://user-images.githubusercontent.com/11507754/172268470-9e6f686a-ab65-477d-9710-fb779a09eef0.png">
