### PR TITLE
Bug: Cannot add Milestone to project with existing Milestone

### DIFF
--- a/schema/data/dev/005_cif_reporting_requirement.sql
+++ b/schema/data/dev/005_cif_reporting_requirement.sql
@@ -30,7 +30,7 @@ do $$
                           and form_data_table_name = 'project'
                         ),
           'reportType', 'General Milestone',
-          'reportingRequirement_index',1,
+          'reportingRequirementIndex',1,
           'maximumAmount', cast(rpad(temp_row.id::text, 3, '0') as bigint),
           'description', 'general milestone report description ' || temp_row.id
           ),


### PR DESCRIPTION
Card: https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/780

This wasn't a bug in the app. There was a typo in the dev data that made any of the pre-existing projects throw this error.