### PR TITLE
chore: override shipit dependency steps

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,3 +1,6 @@
+dependencies:
+  override: []
+
 deploy:
   override:
     - make install:


### PR DESCRIPTION
Now that we have a top-level package.json, shipit tried installing packages with yarn