### PR TITLE
fix: remove sorting for project managers from project list

### DIFF
--- a/app/pages/cif/projects.tsx
+++ b/app/pages/cif/projects.tsx
@@ -112,7 +112,7 @@ export function Projects({ preloadedQuery }: RelayProps<{}, projectsQuery>) {
         "Project Managers",
         "projectManagers",
         allCifUsers.edges.map((e) => e.node.fullName),
-        { allowFreeFormInput: true }
+        { allowFreeFormInput: true, sortable: false }
       ),
       new SortOnlyFilter("Funding Request", "totalFundingRequest"),
       new NoHeaderFilter(),


### PR DESCRIPTION
Issue #744
Removing the ability to sort managers. The sort was causing an error and there is no use in sorting this column as each row contains a list of users.