### PR TITLE
Fix: handle empty project overview

### DIFF
--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -163,6 +163,7 @@ const ProjectForm: React.FC<Props> = (props) => {
       ...revision.projectFormChange.newFormData,
       ...changeData,
     };
+
     return new Promise((resolve, reject) =>
       updateProjectFormChange({
         variables: {

--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -159,13 +159,10 @@ const ProjectForm: React.FC<Props> = (props) => {
     changeData: any,
     changeStatus: "pending" | "staged"
   ) => {
-    // don't trigger a change if the form data is an empty object
-    if (changeData && Object.keys(changeData).length === 0) return;
     const updatedFormData = {
       ...revision.projectFormChange.newFormData,
       ...changeData,
     };
-
     return new Promise((resolve, reject) =>
       updateProjectFormChange({
         variables: {

--- a/schema/deploy/mutations/undo_form_changes.sql
+++ b/schema/deploy/mutations/undo_form_changes.sql
@@ -23,7 +23,7 @@ begin
     else
     -- we need to treat project overview table differently as it needs a null object as form data
       if fc.form_data_table_name = 'project' then
-        update cif.form_change set new_form_data = null where id = fc.id;
+        update cif.form_change set new_form_data = jsonb_build_object() where id = fc.id;
       else
         delete from cif.form_change where id = fc.id;
       end if;

--- a/schema/deploy/util_functions/get_form_status.sql
+++ b/schema/deploy/util_functions/get_form_status.sql
@@ -10,6 +10,7 @@ $function$
 
   select
     case
+    -- return not started for empty project form
       when $2 = 'project'
         and (fc.change_status = 'pending')
         and (select cif.form_change_is_pristine((select row(form_change.*)::cif.form_change from cif.form_change where id=fc.id)) is distinct from true)

--- a/schema/deploy/util_functions/get_form_status.sql
+++ b/schema/deploy/util_functions/get_form_status.sql
@@ -10,6 +10,13 @@ $function$
 
   select
     case
+      when $2 = 'project'
+        and (fc.change_status = 'pending')
+        and (select cif.form_change_is_pristine((select row(form_change.*)::cif.form_change from cif.form_change where id=fc.id)) is distinct from true)
+        and (
+          ((select new_form_data from cif.form_change where id=fc.id) is null)
+          or ((select new_form_data from cif.form_change where id=fc.id) = jsonb_build_object()))
+        then 'Not Started'
       when fc.change_status = 'pending'
         and (select cif.form_change_is_pristine((select row(form_change.*)::cif.form_change from cif.form_change where id=fc.id)) is distinct from true)
         then 'In Progress'

--- a/schema/test/unit/mutations/undo_form_changes_test.sql
+++ b/schema/test/unit/mutations/undo_form_changes_test.sql
@@ -124,9 +124,9 @@ select is(
     select new_form_data from cif.form_change
     where id = 3
   ),
-  null::jsonb
+  jsonb_build_object()
   ,
-  'form changes with no previous form change id are set to empty json when form_data_table name is project'
+  'form changes with no previous form change id are set to empty json object when form_data_table name is project'
 );
 
 select is(


### PR DESCRIPTION
Card: [848](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/848) 

Fixing the bug in the card lead to the `undo changes` button not working. It was calling the `undoFormChange` mutation but would trigger an update with the previous form data, leaving you in the same state as before clicking undo. Fixed by having the function set `new_form_data` to `{}` rather than `null::jsonb`. 
This lead to the tasklist status for project overview showing `in progress` rather than `not started` on an empty form. Fixed by adding a case to `get_form_status` specifically for this scenario.