### PR TITLE
chore: don't show null bc registry ids

### DIFF
--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -53,7 +53,10 @@ export const createProjectUiSchema = (
       "ui:placeholder": "Select an Operator",
       "ui:widget": "SearchWidget",
       "ui:options": {
-        text: `${legalName ? `${legalName} (${bcRegistryId})` : ""}`,
+        text: `${
+          (legalName ? `${legalName}` : "") +
+          (bcRegistryId ? ` (${bcRegistryId})` : "")
+        }`,
       },
     },
     fundingStreamRfpId: {
@@ -203,7 +206,9 @@ const ProjectForm: React.FC<Props> = (props) => {
           anyOf: query.allOperators.edges.map(({ node }) => {
             return {
               type: "number",
-              title: `${node.legalName} (${node.bcRegistryId})`,
+              title: `${node.legalName} ${
+                node.bcRegistryId ? `(${node.bcRegistryId})` : ""
+              }`,
               enum: [node.rowId],
               value: node.rowId,
             };


### PR DESCRIPTION
Card: https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/870

Only show bcRegistryId if it exists for legal operators.