### PR TITLE
refactor: ReadonlyCalculatedWidget can be configured for any value from form context

### DIFF
--- a/app/components/Form/ProjectEmissionIntensityReportForm.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportForm.tsx
@@ -259,7 +259,7 @@ const ProjectEmissionsIntensityReport: React.FC<Props> = (props) => {
             formData={emissionIntensityReportFormChange?.newFormData}
             formContext={{
               form: emissionIntensityReportFormChange?.newFormData,
-              calculatedValue: calculatedEiPerformance,
+              calculatedEiPerformance: calculatedEiPerformance,
               isPercent: true,
             }}
             uiSchema={createEmissionIntensityReportUiSchema(

--- a/app/components/Form/ProjectEmissionIntensityReportForm.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportForm.tsx
@@ -259,7 +259,7 @@ const ProjectEmissionsIntensityReport: React.FC<Props> = (props) => {
             formData={emissionIntensityReportFormChange?.newFormData}
             formContext={{
               form: emissionIntensityReportFormChange?.newFormData,
-              calculatedEiPerformance: calculatedEiPerformance,
+              calculatedEiPerformance: calculatedEiPerformance ?? 0,
               isPercent: true,
             }}
             uiSchema={createEmissionIntensityReportUiSchema(

--- a/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
@@ -56,6 +56,9 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = (props) => {
               formChangeByPreviousFormChangeId {
                 newFormData
               }
+              asEmissionIntensityReport {
+                calculatedEiPerformance
+              }
             }
           }
         }
@@ -175,6 +178,9 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = (props) => {
         )}
         formData={emissionIntensityReportDiffObject.formData}
         formContext={{
+          calculatedEiPerformance:
+            summaryEmissionIntensityReport?.asEmissionIntensityReport
+              .calculatedEiPerformance ?? 0,
           operation: summaryEmissionIntensityReport?.operation,
           oldData:
             summaryEmissionIntensityReport?.formChangeByPreviousFormChangeId

--- a/app/cypress/integration/cif/project-revision/create-project-revision.spec.js
+++ b/app/cypress/integration/cif/project-revision/create-project-revision.spec.js
@@ -178,7 +178,8 @@ describe("when creating a project, the project page", () => {
     // TEIMP section
     cy.findByText(/^Measurement period start date/i)
       .next()
-      .should("have.text", "Jan. 1, 2022");
+      .contains(/Jan(\.)? 1, 2022/)
+      .should("be.visible");
     cy.findByText(/^Functional Unit/i)
       .next()
       .should("have.text", "tCO");

--- a/app/data/jsonSchemaForm/projectEmissionIntensitySchema.ts
+++ b/app/data/jsonSchemaForm/projectEmissionIntensitySchema.ts
@@ -107,6 +107,7 @@ export const emissionIntensityReportUiSchema = {
     "ui:widget": "ReadOnlyCalculatedValueWidget",
     isPercent: true,
     hideOptional: true,
+    calculatedValueFormContextProperty: "calculatedEiPerformance",
   },
   adjustedGHGEmissionIntensityPerformance: {
     "ui:widget": "AdjustableCalculatedValueWidget",

--- a/app/lib/theme/widgets/ReadOnlyCalculatedValueWidget.tsx
+++ b/app/lib/theme/widgets/ReadOnlyCalculatedValueWidget.tsx
@@ -11,16 +11,19 @@ const ReadOnlyCalculatedValueWidget: React.FC<WidgetProps> = ({
   const isMoney = uiSchema?.isMoney;
   const isPercent = uiSchema?.isPercent;
 
+  const calculatedValue =
+    formContext[uiSchema.calculatedValueFormContextProperty];
+
   return (
     <dd>
-      {formContext.calculatedValue ? (
+      {calculatedValue ? (
         <NumberFormat
           fixedDecimalScale={isMoney || isPercent}
           prefix={isMoney ? "$" : ""}
           suffix={isPercent ? "%" : ""}
           id={id}
           decimalScale={isMoney || isPercent ? 2 : 10} //Hardcoded for now, we can change it if we need to
-          value={formContext.calculatedValue}
+          value={calculatedValue}
           displayType="text"
           aria-label={label}
         />

--- a/app/lib/theme/widgets/ReadOnlyCalculatedValueWidget.tsx
+++ b/app/lib/theme/widgets/ReadOnlyCalculatedValueWidget.tsx
@@ -16,7 +16,7 @@ const ReadOnlyCalculatedValueWidget: React.FC<WidgetProps> = ({
 
   return (
     <dd>
-      {calculatedValue ? (
+      {calculatedValue !== null && calculatedValue !== undefined ? (
         <NumberFormat
           fixedDecimalScale={isMoney || isPercent}
           prefix={isMoney ? "$" : ""}
@@ -34,7 +34,7 @@ const ReadOnlyCalculatedValueWidget: React.FC<WidgetProps> = ({
           suffix={isPercent ? "%" : ""}
           id={id}
           decimalScale={isMoney || isPercent ? 2 : 10}
-          value={0}
+          value={""}
           displayType="text"
           aria-label={label}
         />

--- a/app/lib/theme/widgets/ReadOnlyCalculatedValueWidget.tsx
+++ b/app/lib/theme/widgets/ReadOnlyCalculatedValueWidget.tsx
@@ -4,7 +4,7 @@ import NumberFormat from "react-number-format";
 const ReadOnlyCalculatedValueWidget: React.FC<WidgetProps> = ({
   id,
   formContext,
-  label,
+
   uiSchema,
 }) => {
   // If we are using this widget to show numbers as money or percent, we can set `isMoney` or `isPercent` to true in the uiSchema.
@@ -15,28 +15,24 @@ const ReadOnlyCalculatedValueWidget: React.FC<WidgetProps> = ({
     formContext[uiSchema.calculatedValueFormContextProperty];
 
   return (
-    <dd>
+    <dd id={id}>
       {calculatedValue !== null && calculatedValue !== undefined ? (
         <NumberFormat
           fixedDecimalScale={isMoney || isPercent}
           prefix={isMoney ? "$" : ""}
           suffix={isPercent ? "%" : ""}
-          id={id}
           decimalScale={isMoney || isPercent ? 2 : 10} //Hardcoded for now, we can change it if we need to
           value={calculatedValue}
           displayType="text"
-          aria-label={label}
         />
       ) : (
         <NumberFormat
           fixedDecimalScale={isMoney || isPercent}
           prefix={isMoney ? "$" : ""}
           suffix={isPercent ? "%" : ""}
-          id={id}
           decimalScale={isMoney || isPercent ? 2 : 10}
           value={""}
           displayType="text"
-          aria-label={label}
         />
       )}
     </dd>

--- a/app/tests/unit/components/Form/ProjectEmissionIntensityReportForm.test.tsx
+++ b/app/tests/unit/components/Form/ProjectEmissionIntensityReportForm.test.tsx
@@ -173,11 +173,16 @@ describe("the emission intensity report form component", () => {
     expect(
       screen.getByLabelText(/Total lifetime emissions reductions*/i)
     ).toHaveValue("5");
+
+    // We can't query by label for text elements,
+    // See 'note' field here https://testing-library.com/docs/queries/bylabeltext/#options
     expect(
-      screen.getAllByLabelText(/GHG Emission Intensity Performance/i)[0]
-    ).toHaveTextContent("200.00%");
+      screen.queryByText("GHG Emission Intensity Performance")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("200.00%")).toBeInTheDocument();
+
     expect(
-      screen.getAllByLabelText(/GHG Emission Intensity Performance/i)[1]
+      screen.getByLabelText(/GHG Emission Intensity Performance \(Adjusted\)/i)
     ).toHaveValue("6.00%");
   });
 

--- a/app/tests/unit/components/Form/ProjectEmissionIntensityReportForm.test.tsx
+++ b/app/tests/unit/components/Form/ProjectEmissionIntensityReportForm.test.tsx
@@ -186,6 +186,36 @@ describe("the emission intensity report form component", () => {
     ).toHaveValue("6.00%");
   });
 
+  it("renders 0% for the GHG emissions performance if the calculated value is null", () => {
+    const mockResolver = {
+      ...defaultMockResolver,
+      ProjectRevision(context, generateID) {
+        return {
+          ...defaultMockResolver.ProjectRevision(context, generateID),
+          emissionIntensityReportFormChange: {
+            edges: [
+              {
+                node: {
+                  ...defaultMockResolver.ProjectRevision(context, generateID)
+                    .emissionIntensityReportFormChange.edges[0].node,
+                  asEmissionIntensityReport: {
+                    calculatedEiPerformance: null,
+                  },
+                },
+              },
+            ],
+            __id: "client:mock:__connection_emissionIntensityReportFormChange_connection",
+          },
+        };
+      },
+    };
+
+    componentTestingHelper.loadQuery(mockResolver);
+    componentTestingHelper.renderComponent();
+
+    expect(screen.queryByText("0.00%")).toBeInTheDocument();
+  });
+
   it("uses useMutationWithErrorMessage and returns expected message when the user clicks the Add button and there's a mutation error", () => {
     const mockResolver = {
       ...defaultMockResolver,

--- a/app/tests/unit/components/Form/ProjectEmissionIntensityReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectEmissionIntensityReportFormSummary.test.tsx
@@ -97,7 +97,6 @@ describe("the emission intensity report form component", () => {
   it("only displays the data fields that have changed", () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();
-    screen.logTestingPlaygroundURL();
     expect(screen.getByText(/bulbasaur/i)).toBeInTheDocument();
   });
 

--- a/app/tests/unit/lib/theme/widgets/ReadOnlyCalculatedValueWidget.test.tsx
+++ b/app/tests/unit/lib/theme/widgets/ReadOnlyCalculatedValueWidget.test.tsx
@@ -9,10 +9,11 @@ describe("The ReadOnlyCalculatedValueWidget", () => {
       label: "test-label",
       uiSchema: {
         calculatedValueFormContextProperty: "someprop",
+        isMoney: true,
       },
     };
     render(<ReadOnlyCalculatedValueWidget {...props} />);
-    expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("50");
+    expect(screen.getByText("$50.00")).toBeInTheDocument();
   });
 
   it("renders 0 if the calculated value is zero", () => {
@@ -25,7 +26,7 @@ describe("The ReadOnlyCalculatedValueWidget", () => {
       },
     };
     render(<ReadOnlyCalculatedValueWidget {...props} />);
-    expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("0");
+    expect(screen.getByText("0")).toBeInTheDocument();
   });
 
   it("renders empty string if the calculated value is null", () => {
@@ -38,6 +39,6 @@ describe("The ReadOnlyCalculatedValueWidget", () => {
       },
     };
     render(<ReadOnlyCalculatedValueWidget {...props} />);
-    expect(screen.getByLabelText(/test-label/i)).not.toHaveTextContent("0");
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 });

--- a/app/tests/unit/lib/theme/widgets/ReadOnlyCalculatedValueWidget.test.tsx
+++ b/app/tests/unit/lib/theme/widgets/ReadOnlyCalculatedValueWidget.test.tsx
@@ -15,7 +15,20 @@ describe("The ReadOnlyCalculatedValueWidget", () => {
     expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("50");
   });
 
-  it("renders 0 if the calculated value is null", () => {
+  it("renders 0 if the calculated value is zero", () => {
+    const props: any = {
+      id: "test-id",
+      formContext: { someprop: 0 },
+      label: "test-label",
+      uiSchema: {
+        calculatedValueFormContextProperty: "someprop",
+      },
+    };
+    render(<ReadOnlyCalculatedValueWidget {...props} />);
+    expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("0");
+  });
+
+  it("renders empty string if the calculated value is null", () => {
     const props: any = {
       id: "test-id",
       formContext: { someprop: null },
@@ -25,6 +38,6 @@ describe("The ReadOnlyCalculatedValueWidget", () => {
       },
     };
     render(<ReadOnlyCalculatedValueWidget {...props} />);
-    expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("0");
+    expect(screen.getByLabelText(/test-label/i)).not.toHaveTextContent("0");
   });
 });

--- a/app/tests/unit/lib/theme/widgets/ReadOnlyCalculatedValueWidget.test.tsx
+++ b/app/tests/unit/lib/theme/widgets/ReadOnlyCalculatedValueWidget.test.tsx
@@ -2,21 +2,27 @@ import { render, screen } from "@testing-library/react";
 import ReadOnlyCalculatedValueWidget from "lib/theme/widgets/ReadOnlyCalculatedValueWidget";
 
 describe("The ReadOnlyCalculatedValueWidget", () => {
-  it("renders the calculated value", () => {
+  it("renders the calculated value from the form context as specified in the uiSchema", () => {
     const props: any = {
       id: "test-id",
-      formContext: { calculatedValue: 50 },
+      formContext: { someprop: 50 },
       label: "test-label",
+      uiSchema: {
+        calculatedValueFormContextProperty: "someprop",
+      },
     };
     render(<ReadOnlyCalculatedValueWidget {...props} />);
     expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("50");
   });
 
-  it("renders 0% if the calculated value is null", () => {
+  it("renders 0 if the calculated value is null", () => {
     const props: any = {
       id: "test-id",
-      formContext: { calculatedValue: null },
+      formContext: { someprop: null },
       label: "test-label",
+      uiSchema: {
+        calculatedValueFormContextProperty: "someprop",
+      },
     };
     render(<ReadOnlyCalculatedValueWidget {...props} />);
     expect(screen.getByLabelText(/test-label/i)).toHaveTextContent("0");


### PR DESCRIPTION
This was preventing us from using multiple `ReadonlyCalculatedWidget` widgets on one form