### PR TITLE
chore: fix AdjustableCalculatedValueWidget validation errors

### DIFF
--- a/app/lib/theme/widgets/AdjustableCalculatedValueWidget.tsx
+++ b/app/lib/theme/widgets/AdjustableCalculatedValueWidget.tsx
@@ -60,7 +60,7 @@ export const AdjustableCalculatedValueWidget: React.FC<WidgetProps> = (
             floatValue === undefined ||
             floatValue === null
           ) {
-            onChange(null);
+            onChange(undefined);
           } else {
             onChange(((floatValue * 100) / 100).toFixed(isMoney ? 2 : 10)); //Hardcoded for now, we can change it if we need to
           }

--- a/app/tests/unit/lib/theme/widgets/AdjustableCalculatedValueWidget.test.tsx
+++ b/app/tests/unit/lib/theme/widgets/AdjustableCalculatedValueWidget.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { AdjustableCalculatedValueWidget } from "lib/theme/widgets/AdjustableCalculatedValueWidget";
 
 describe("The AdjustableCalculatedValueWidget", () => {
@@ -50,5 +51,23 @@ describe("The AdjustableCalculatedValueWidget", () => {
     };
     render(<AdjustableCalculatedValueWidget {...props} />);
     expect(screen.getByLabelText(/test label \(adjusted\)/i)).toHaveValue("");
+  });
+
+  it("sets value to undefined when the field is cleared", () => {
+    const props: any = {
+      uiSchema: { isMoney: true, calculatedValueFormContextProperty: "myProp" },
+      schema: { type: "number", title: "Test Label", default: undefined },
+      id: "test-id",
+      label: "Test Label",
+      onChange: jest.fn(),
+      value: "1",
+      formContext: { myProp: "100" },
+    };
+    render(<AdjustableCalculatedValueWidget {...props} />);
+    userEvent.clear(
+      screen.getByRole("textbox", { name: /test label \(adjusted\)/i })
+    );
+
+    expect(props.onChange).toHaveBeenLastCalledWith(undefined);
   });
 });


### PR DESCRIPTION
Card: https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/971

Previously the `AdjustableCalculatedValueWidget` set empty values to `null` which caused validation errors on an empty field after clearing it. Setting it to `undefined` in those cases fixes this.