### PR TITLE
Fix: separate quarterly and teimp statuses

### DIFF
--- a/app/components/TaskList/index.tsx
+++ b/app/components/TaskList/index.tsx
@@ -53,6 +53,7 @@ const TaskList: React.FC<Props> = ({ projectRevision, mode }) => {
     annualReportsStatus,
     milestoneReportStatuses,
     fundingAgreementStatus,
+    teimpStatus,
   } = useFragment(
     // The JSON string is tripping up eslint
     // eslint-disable-next-line relay/graphql-syntax
@@ -78,6 +79,9 @@ const TaskList: React.FC<Props> = ({ projectRevision, mode }) => {
         annualReportsStatus: tasklistStatusFor(
           formDataTableName: "reporting_requirement"
           jsonMatcher: "{\"reportType\":\"Annual\"}"
+        )
+        teimpStatus: tasklistStatusFor(
+          formDataTableName: "emission_intensity_report"
         )
         fundingAgreementStatus: tasklistStatusFor(formDataTableName: "funding_parameter")
         milestoneReportStatuses {
@@ -268,8 +272,7 @@ const TaskList: React.FC<Props> = ({ projectRevision, mode }) => {
         {useShowGrowthbookFeature("teimp") && (
           <TaskListSection
             defaultExpandedState={
-              currentStep === "6" ||
-              quarterlyReportsStatus === ATTENTION_REQUIRED_STATUS
+              currentStep === "6" || teimpStatus === ATTENTION_REQUIRED_STATUS
             }
             listItemNumber="6"
             listItemName="Emissions Intensity Report"
@@ -278,7 +281,7 @@ const TaskList: React.FC<Props> = ({ projectRevision, mode }) => {
               stepName="6"
               linkUrl={getProjectRevisionFormPageRoute(id, 6)}
               formTitle="Emissions Intensity Report"
-              formStatus={quarterlyReportsStatus}
+              formStatus={teimpStatus}
               currentStep={currentStep}
               mode={mode}
             />

--- a/app/cypress/integration/cif/project-revision/index.spec.js
+++ b/app/cypress/integration/cif/project-revision/index.spec.js
@@ -232,6 +232,7 @@ describe("the new project page", () => {
     );
 
     // Emissions intensity report
+    cy.findByText(/Emissions Intensity Report/i).click();
     cy.findByText(/Add emissions intensity report/i).click();
     cy.url().should("include", "/form/6");
 


### PR DESCRIPTION
Card: https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/972
A couple notes:
- this PR separates the quarterly report and TEIMP statuses, but there's still a bug with the TEIMP status captured in [this card](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/970)
- the regression test is the happo screenshot with the separated statuses