### PR TITLE
Chore: verify function not present with schema

### DIFF
--- a/schema/data/dev/002_cif_operator.sql
+++ b/schema/data/dev/002_cif_operator.sql
@@ -34,9 +34,13 @@ values
   "bcRegistryId": "EF3456789",
   "operatorCode": "IJKL" }', 'create', 'cif', 'operator', 'pending', 'operator');
 
--- Commit records
-select cif_private.commit_form_change_internal(row(form_change.*)::cif.form_change)
-  from cif.form_change
-  where form_data_table_name='operator';
+do $$
+  begin
+  -- Commit records
+    perform cif_private.commit_form_change_internal(row(form_change.*)::cif.form_change)
+      from cif.form_change
+      where form_data_table_name='operator';
+  end
+$$;
 
 commit;

--- a/schema/data/dev/007_commit_project_revision.sql
+++ b/schema/data/dev/007_commit_project_revision.sql
@@ -1,4 +1,9 @@
 begin;
 
-select cif.commit_project_revision(id) from cif.project_revision;
+do $$
+  begin
+    perform cif.commit_project_revision(id) from cif.project_revision;
+  end
+$$;
+
 commit;

--- a/schema/deploy/util_functions/verify_function_not_present.sql
+++ b/schema/deploy/util_functions/verify_function_not_present.sql
@@ -2,19 +2,29 @@
 
 begin;
 
-create or replace function cif_private.verify_function_not_present(function_name text)
+drop function cif_private.verify_function_not_present;
+
+create or replace function cif_private.verify_function_not_present(function_schema_name text, function_name text, number_of_parameters int)
 returns boolean
 as
 $function$
 begin
-  if (select exists(select * from pg_proc where proname=function_name)) then
-    raise exception '% exists when it should not', function_name;
+  if (select exists(
+        select * from pg_proc
+        join pg_namespace
+          on pg_proc.pronamespace = pg_namespace.oid
+          and pg_namespace.nspname = function_schema_name
+          and proname=function_name
+          and pronargs = number_of_parameters
+      )
+     ) then
+      raise exception '% exists when it should not', function_name;
   else
     return true;
   end if;
 end;
 $function$
 language 'plpgsql' stable;
-comment on function cif_private.verify_function_not_present(text) is 'Utility function to use in a change verification or test to ensure that a function was deleted';
+comment on function cif_private.verify_function_not_present(text, text, int) is 'Utility function to use in a change verification or test to ensure that a function was deleted';
 
 commit;

--- a/schema/deploy/util_functions/verify_function_not_present@1.0.0-rc.4.sql
+++ b/schema/deploy/util_functions/verify_function_not_present@1.0.0-rc.4.sql
@@ -2,8 +2,6 @@
 
 begin;
 
-drop function cif_private.verify_function_not_present;
-
 create or replace function cif_private.verify_function_not_present(function_name text)
 returns boolean
 as

--- a/schema/revert/computed_columns/form_change_as_emission_intensity_report.sql
+++ b/schema/revert/computed_columns/form_change_as_emission_intensity_report.sql
@@ -2,6 +2,15 @@
 
 begin;
 
+/**
+  The revert for the preceding change emission_intensity_report_001 must be done here or the revert for form_change_as_emission_intensity_report
+  will not work. It will complain that it is returning too few columns.
+**/
+
+alter table cif.emission_intensity_report
+  drop column if exists adjusted_holdback_payment_amount,
+  drop column if exists date_sent_to_csnr;
+
 create or replace function cif.form_change_as_emission_intensity_report(cif.form_change)
 returns cif.emission_intensity_report
 as $$

--- a/schema/revert/computed_columns/form_change_as_project.sql
+++ b/schema/revert/computed_columns/form_change_as_project.sql
@@ -5,6 +5,11 @@
 
 begin;
 
+/** The revert for the preceding change project_001 must be done here or the revert for form_change_as_project will not work.
+    It will complain that it is returning too few columns.
+**/
+alter table cif.project drop column if exists score, drop column if exists project_type;
+
 create or replace function cif.form_change_as_project(cif.form_change)
 returns cif.project
 as $$
@@ -31,7 +36,7 @@ as $$
       null::int as updated_by,
       now()::timestamptz updated_at,
       null::int as archived_by,
-      null::timestamptz as archived_at,
+      null::timestamptz as archived_at
     from cif.form_change fc where fc.id = $1.id and fc.form_data_table_name = 'project'
 
 $$ language sql stable;

--- a/schema/revert/computed_columns/project_revision_teimp_payment_amount.sql
+++ b/schema/revert/computed_columns/project_revision_teimp_payment_amount.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-drop function cif.project_revision_teimp_payment_percentage;
+drop function cif.project_revision_teimp_payment_amount;
 
 commit;

--- a/schema/revert/tables/emission_intensity_report_001.sql
+++ b/schema/revert/tables/emission_intensity_report_001.sql
@@ -2,8 +2,14 @@
 
 begin;
 
+/**
+  The revert for emission_intensity_report_001 should already have been run in computed_columns/form_change_as_project as the columns need to be
+  dropped for the function to properly be reverted. This revert will only be called in a development context where sqitch
+  only got deployed to emission_intensity_report_001.
+**/
+
 alter table cif.emission_intensity_report
-  drop column adjusted_holdback_payment_amount,
-  drop column date_sent_to_csnr;
+  drop column if exists adjusted_holdback_payment_amount,
+  drop column if exists date_sent_to_csnr;
 
 commit;

--- a/schema/revert/tables/project_001.sql
+++ b/schema/revert/tables/project_001.sql
@@ -2,9 +2,10 @@
 
 begin;
 
-/** The revert for project_001 should already have been run in computed_columns/form_change_as_project as the columns need to be
-    dropped for the function to properly be reverted. This revert will only be called in a development context where sqitch
-    only got deployed to project_001.
+/**
+  The revert for project_001 should already have been run in computed_columns/form_change_as_project as the columns need to be
+  dropped for the function to properly be reverted. This revert will only be called in a development context where sqitch
+  only got deployed to project_001.
 **/
 alter table cif.project drop column if exists score, drop column if exists project_type;
 

--- a/schema/revert/tables/project_001.sql
+++ b/schema/revert/tables/project_001.sql
@@ -2,6 +2,10 @@
 
 begin;
 
-alter table cif.project drop column score, drop column project_type;
+/** The revert for project_001 should already have been run in computed_columns/form_change_as_project as the columns need to be
+    dropped for the function to properly be reverted. This revert will only be called in a development context where sqitch
+    only got deployed to project_001.
+**/
+alter table cif.project drop column if exists score, drop column if exists project_type;
 
 commit;

--- a/schema/revert/util_functions/verify_function_not_present@1.0.0-rc.4.sql
+++ b/schema/revert/util_functions/verify_function_not_present@1.0.0-rc.4.sql
@@ -1,0 +1,7 @@
+-- Revert cif:util_functions/verify_function_not_present from pg
+
+begin;
+
+drop function cif_private.verify_function_not_present(text);
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -136,3 +136,4 @@ mutations/add_emission_intensity_report_to_revision [mutations/add_emission_inte
 computed_columns/project_revision_tasklist_status_for [computed_columns/project_revision_tasklist_status_for@1.0.0-rc.4] 2022-08-29T21:49:01Z Dylan Leard <dylan@button.is> # Migration: Attention Required status should be the first priority loop exit
 tables/amendment_type 2022-08-22T23:55:53Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Table to store different amendment types
 tables/project_revision_amendment_type [tables/project_revision tables/amendment_type] 2022-08-23T16:13:22Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Join table to store the amendment type of the project revision
+util_functions/verify_function_not_present [util_functions/verify_function_not_present@1.0.0-rc.4] 2022-08-22T18:14:11Z Dylan Leard <dylan@button.is> # Migration: verify function should also check the schema

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -105,6 +105,7 @@ computed_columns/form_change_as_emission_intensity_report 2022-08-03T17:12:52Z B
 @1.0.0-rc.3 2022-08-08T22:14:42Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # release v1.0.0-rc.3
 mutations/discard_funding_parameter_form_change 2022-08-10T23:11:54Z Gurjeet Matharu <gurjeet@matharuco.com> # Discarding funding parameter form change
 @1.0.0-rc.4 2022-08-15T18:49:49Z Dylan Leard <dylan@button.is> # release v1.0.0-rc.4
+util_functions/verify_function_not_present [util_functions/verify_function_not_present@1.0.0-rc.4] 2022-08-22T18:14:11Z Dylan Leard <dylan@button.is> # Migration: verify function should also check the schema
 tables/project_type 2022-08-08T18:26:33Z Brianna Cerkiewicz <briannacerkiewicz@pop-os> # Adding a table for project type
 tables/project_001 2022-08-08T15:28:44Z Brianna Cerkiewicz <briannacerkiewicz@pop-os> # Add a score and project type column to the project table
 computed_columns/form_change_as_project [computed_columns/form_change_as_project@1.0.0-rc.1 tables/project_001] 2022-08-08T21:44:08Z Brianna Cerkiewicz <briannacerkiewicz@pop-os> # Add score and project type to project computed column
@@ -136,4 +137,3 @@ mutations/add_emission_intensity_report_to_revision [mutations/add_emission_inte
 computed_columns/project_revision_tasklist_status_for [computed_columns/project_revision_tasklist_status_for@1.0.0-rc.4] 2022-08-29T21:49:01Z Dylan Leard <dylan@button.is> # Migration: Attention Required status should be the first priority loop exit
 tables/amendment_type 2022-08-22T23:55:53Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Table to store different amendment types
 tables/project_revision_amendment_type [tables/project_revision tables/amendment_type] 2022-08-23T16:13:22Z Sepehr Sobhani <sepehr.sobhani@gov.bc.ca> # Join table to store the amendment type of the project revision
-util_functions/verify_function_not_present [util_functions/verify_function_not_present@1.0.0-rc.4] 2022-08-22T18:14:11Z Dylan Leard <dylan@button.is> # Migration: verify function should also check the schema

--- a/schema/test/unit/util_functions/verify_function_not_present_test.sql
+++ b/schema/test/unit/util_functions/verify_function_not_present_test.sql
@@ -1,7 +1,9 @@
 begin;
-select plan(2);
+select plan(4);
 
-create function some_function()
+create schema test_schema;
+
+create function test_schema.some_function(int)
 returns boolean
 as
 $function$
@@ -10,14 +12,26 @@ $function$
 language sql;
 
 select throws_like(
-  $$select cif_private.verify_function_not_present('some_function')$$,
+  $$select cif_private.verify_function_not_present('test_schema', 'some_function', 1)$$,
   '% exists when it should not',
   'verify_function_not_present throws an exception if the function exists'
 );
 
-drop function some_function;
 select is(
-  (select cif_private.verify_function_not_present('some_function')),
+  (select cif_private.verify_function_not_present('test_schem', 'some_function', 1)),
+  true,
+  'verify_function_not_present returns true if the function does not exist in the given schema'
+);
+
+select is(
+  (select cif_private.verify_function_not_present('test_schem', 'some_function', 2)),
+  true,
+  'verify_function_not_present returns true if a function with a matching number of parameters does not exist'
+);
+
+drop function test_schema.some_function;
+select is(
+  (select cif_private.verify_function_not_present('test_schema', 'some_function', 1)),
   true,
   'verify_function_not_present returns true if the function does not exist'
 );

--- a/schema/verify/trigger_functions/commit_form_change.sql
+++ b/schema/verify/trigger_functions/commit_form_change.sql
@@ -2,6 +2,6 @@
 
 begin;
 
--- TODO use a verify_function_not_present that includes the schema name and parameter types
+select cif_private.verify_function_not_present('cif_private', 'commit_form_change', 0);
 
 rollback;

--- a/schema/verify/trigger_functions/commit_project_revision.sql
+++ b/schema/verify/trigger_functions/commit_project_revision.sql
@@ -2,6 +2,6 @@
 
 begin;
 
--- TODO use a verify_function_not_present that includes the schema name and parameter types
+select cif_private.verify_function_not_present('cif_private', 'commit_project_revision', 0);
 
 rollback;

--- a/schema/verify/util_functions/verify_function_not_present.sql
+++ b/schema/verify/util_functions/verify_function_not_present.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-select pg_get_functiondef('cif_private.verify_function_not_present(text)'::regprocedure);
+select pg_get_functiondef('cif_private.verify_function_not_present(text,text,int)'::regprocedure);
 
 rollback;

--- a/schema/verify/util_functions/verify_function_not_present@1.0.0-rc.4.sql
+++ b/schema/verify/util_functions/verify_function_not_present@1.0.0-rc.4.sql
@@ -1,0 +1,7 @@
+-- Verify cif:util_functions/verify_function_not_present on pg
+
+begin;
+
+select pg_get_functiondef('cif_private.verify_function_not_present(text)'::regprocedure);
+
+rollback;


### PR DESCRIPTION
- change verify_function_not_present utility function to include schema and number of input parameters in the check
- fix broken revert logic
- add missing verify checks for deleted trigger functions `commit_form_change` and `commit_project_revision`
- fix dev data so it doesn't output unncessary lines to the console
