### PR TITLE
Feat/optional contact phone number

### DIFF
--- a/app/data/jsonSchemaForm/contactSchema.ts
+++ b/app/data/jsonSchemaForm/contactSchema.ts
@@ -1,7 +1,7 @@
 const contactSchema = {
   $schema: "http://json-schema.org/draft-07/schema",
   type: "object",
-  required: ["givenName", "familyName", "email", "phone"],
+  required: ["givenName", "familyName", "email"],
   properties: {
     givenName: {
       type: "string",

--- a/app/tests/unit/components/Contact/ContactForm.test.tsx
+++ b/app/tests/unit/components/Contact/ContactForm.test.tsx
@@ -48,7 +48,6 @@ const componentTestingHelper = new ComponentTestingHelper<ContactFormTestQuery>(
 describe("The Contact Form component", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-
     componentTestingHelper.reinit();
   });
 
@@ -95,7 +94,43 @@ describe("The Contact Form component", () => {
     });
   });
 
-  it("displays the correct validation erros when submit is clicked with invalid data", () => {
+  it("submits the form data when optional data is left out", () => {
+    componentTestingHelper.loadQuery({
+      FormChange() {
+        const result: Partial<ContactForm_formChange> = {
+          newFormData: {
+            email: "foo@example.com",
+            givenName: "Scooby",
+            familyName: "Doo",
+          },
+          isUniqueValue: true,
+          id: "abc",
+          changeStatus: "pending",
+          formDataRecordId: 1,
+        };
+        return result;
+      },
+    });
+    componentTestingHelper.renderComponent();
+
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    expect(
+      componentTestingHelper.environment.mock.getMostRecentOperation().request
+        .variables.input
+    ).toMatchObject({
+      formChangePatch: {
+        changeStatus: "committed",
+        newFormData: {
+          email: "foo@example.com",
+          familyName: "Doo",
+          givenName: "Scooby",
+        },
+      },
+      id: "abc",
+    });
+  });
+
+  it("displays the correct validation errors when submit is clicked with invalid data", () => {
     const mockResolver = {
       FormChange() {
         const result: Partial<ContactForm_formChange> = {


### PR DESCRIPTION
Card: https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/869

re this bullet in the developer checklist: `Phone number is not enforced in the database (can be null)`--I didn't have to change anything, it was already set up like that