### PR TITLE
Fix/clear existing project manager

### DIFF
--- a/app/components/Form/ProjectManagerFormGroup.tsx
+++ b/app/components/Form/ProjectManagerFormGroup.tsx
@@ -136,6 +136,7 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
           rowId,
           formChangePatch: {
             newFormData,
+            operation: "UPDATE",
           },
         },
       },
@@ -145,7 +146,7 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
             id: formChangeId,
             changeStatus: "pending",
             newFormData,
-            operation: undefined,
+            operation: "UPDATE",
             projectRevisionByProjectRevisionId: undefined,
           },
         },

--- a/app/components/Form/ProjectManagerFormGroup.tsx
+++ b/app/components/Form/ProjectManagerFormGroup.tsx
@@ -36,6 +36,7 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
         id
         rowId
         changeStatus
+        isFirstRevision
         managerFormChanges: projectManagerFormChangesByLabel(first: 1000)
           @connection(key: "ProjectManagerFormGroup_managerFormChanges") {
           edges {
@@ -136,7 +137,8 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
           rowId,
           formChangePatch: {
             newFormData,
-            operation: "UPDATE",
+            // a temporary fix to make sure the form change operation is set correctly
+            operation: projectRevision.isFirstRevision ? "CREATE" : "UPDATE",
           },
         },
       },
@@ -146,7 +148,7 @@ const ProjectManagerFormGroup: React.FC<Props> = (props) => {
             id: formChangeId,
             changeStatus: "pending",
             newFormData,
-            operation: "UPDATE",
+            operation: projectRevision.isFirstRevision ? "CREATE" : "UPDATE",
             projectRevisionByProjectRevisionId: undefined,
           },
         },

--- a/app/tests/unit/components/Form/ProjectManagerFormGroup.test.tsx
+++ b/app/tests/unit/components/Form/ProjectManagerFormGroup.test.tsx
@@ -203,6 +203,7 @@ describe("The ProjectManagerForm", () => {
               projectId: 1,
               projectManagerLabelId: 2,
             },
+            operation: "UPDATE",
           },
         },
       }


### PR DESCRIPTION
ZH: https://github.com/bcgov/cas-cif/issues/1040

The project manager kept coming as `ARCHIVED` so when choosing a new manager, the form change stays as `ARCHIVED` and doesn't show up in the form.

- Code updated based on the conversation with Dylan. This bug revealed another bugs ([#1066](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/1066) and [#1068](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/1068))
- We are conditionally passing operation here but there's a possibility to change this down the road.