### PR TITLE
Test: fix bug that makes create-project-revision fail locally

### DIFF
--- a/app/cypress/integration/cif/project-revision/create-project-revision.spec.js
+++ b/app/cypress/integration/cif/project-revision/create-project-revision.spec.js
@@ -96,9 +96,6 @@ describe("when creating a project, the project page", () => {
     );
     cy.findAllByRole("status").first().should("have.text", "Complete");
     cy.contains("Changes saved").should("be.visible");
-    cy.get('[aria-label="General Comments"]')
-      .eq(0)
-      .should("have.value", "I am the first general comment");
     cy.happoAndAxe("Project quarterly reports Form", "filled", "main");
     cy.contains("Changes saved").should("be.visible");
     cy.findByText(/^submit/i).click();


### PR DESCRIPTION
The create-project-revision test always fails locally for me. This fixes it.