### PR TITLE
Refactor/read only number widget

### DIFF
--- a/app/cypress/integration/cif/project-revision/create-project-revision.spec.js
+++ b/app/cypress/integration/cif/project-revision/create-project-revision.spec.js
@@ -152,7 +152,7 @@ describe("when creating a project, the project page", () => {
       .should("have.text", "Bar");
     cy.findByText(/Total Funding Request/i)
       .next()
-      .should("have.text", "$100.00");
+      .should("have.value", "$100.00");
     cy.findByText(/Project Status/i)
       .next()
       .should("have.text", "Project Underway");
@@ -179,7 +179,7 @@ describe("when creating a project, the project page", () => {
       .should("have.text", "Test Source 1");
     cy.findByText(/Additional Funding Amount \(Source 1\)/i)
       .next()
-      .should("have.text", "$111.00");
+      .should("have.value", "$111.00");
     cy.findByText(/Additional Funding Status \(Source 1\)/i)
       .next()
       .should("have.text", "Approved");

--- a/app/cypress/support/commands.js
+++ b/app/cypress/support/commands.js
@@ -569,22 +569,22 @@ Cypress.Commands.add(
   ) => {
     cy.findByText(/Total Project Value$/i)
       .next()
-      .should("have.text", totalProjectValue);
+      .should("have.value", totalProjectValue);
     cy.findByText(/Max Funding Amount$/i)
       .next()
-      .should("have.text", maxFundingAmount);
+      .should("have.value", maxFundingAmount);
     cy.findByText(/Province Share Percentage$/i)
       .next()
-      .should("have.text", provinceSharePercentage);
+      .should("have.value", provinceSharePercentage);
     cy.findByText(/Holdback Percentage$/i)
       .next()
-      .should("have.text", holdbackPercentage);
+      .should("have.value", holdbackPercentage);
     cy.findByText(/Anticipated Funding Amount$/i)
       .next()
-      .should("have.text", anticipatedFundingAmount);
+      .should("have.value", anticipatedFundingAmount);
     cy.findByText(/Proponent Cost$/i)
       .next()
-      .should("have.text", proponentCost);
+      .should("have.value", proponentCost);
 
     cy.findByText(/Contract Start Date$/i)
       .next()
@@ -649,7 +649,7 @@ Cypress.Commands.add(
     cy.findAllByText(/^Additional Funding Amount/i)
       .eq(sourceNumber - 1)
       .next()
-      .should("have.text", amount);
+      .should("have.value", amount);
     cy.findAllByText(/^Additional Funding Status/i)
       .eq(sourceNumber - 1)
       .next()

--- a/app/lib/theme/widgets/ReadOnlyNumberWidget.tsx
+++ b/app/lib/theme/widgets/ReadOnlyNumberWidget.tsx
@@ -5,6 +5,7 @@ const ReadOnlyNumberWidget: React.FC<WidgetProps> = ({
   id,
   value,
   uiSchema,
+  label,
 }) => {
   // If we are using this widget to show numbers as money or percent, we can set `isMoney` or `isPercentage` to true in the uiSchema.
   const isMoney = uiSchema?.isMoney;
@@ -16,11 +17,11 @@ const ReadOnlyNumberWidget: React.FC<WidgetProps> = ({
     : uiSchema.numberOfDecimalPlaces ?? 0;
 
   return (
-    <dd>
+    <>
       {value ? (
         <NumberFormat
           value={value}
-          displayType="text"
+          readOnly
           thousandSeparator
           fixedDecimalScale={numberOfDecimalPlaces}
           decimalScale={numberOfDecimalPlaces}
@@ -28,11 +29,25 @@ const ReadOnlyNumberWidget: React.FC<WidgetProps> = ({
           prefix={isMoney ? "$" : ""}
           suffix={isPercentage ? " %" : ""}
           className="decimal"
+          style={{
+            border: "none",
+            padding: "0 0 0 0.75em",
+          }}
+          aria-label={label}
         />
       ) : (
-        <em>Not added</em>
+        <input
+          value={"Not added"}
+          disabled
+          style={{
+            color: "hsla(0,0%,0%,0.8)",
+            border: "none",
+            padding: "0 0 0 0.75em",
+            fontStyle: "italic",
+          }}
+        />
       )}
-    </dd>
+    </>
   );
 };
 

--- a/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
+++ b/app/tests/unit/pages/project-revision/[projectRevision]/index.test.tsx
@@ -299,7 +299,9 @@ describe("The Create Project page", () => {
     expect(screen.getByText(/test-project-name/i)).toBeInTheDocument();
     expect(screen.getByText(/test-project-status-name/i)).toBeInTheDocument();
     expect(screen.getByText(/test-prop-reference/i)).toBeInTheDocument();
-    expect(screen.getByText(/\$5.00/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Total Funding Request/i)).toHaveValue(
+      "$5.00"
+    );
     expect(
       screen.getByText(/test-funding-stream-description - 2020/i)
     ).toBeInTheDocument();


### PR DESCRIPTION
Partially addresses card: https://github.com/bcgov/cas-cif/issues/563

New approach: Make a non-readonly version of the calculated widget for use in forms that would display an input tag, in read-only mode, with the proper styling so that it shows up as text (keep the readonly version in the summary)