### PR TITLE
fix: remove caret from project revision tasklist when has no child

### DIFF
--- a/app/components/TaskList/ProjectRevisionChangeLogsTaskListSection.tsx
+++ b/app/components/TaskList/ProjectRevisionChangeLogsTaskListSection.tsx
@@ -43,11 +43,11 @@ const ProjectRevisionChangeLogsTaskListSection: React.FC<Props> = ({
           aria-controls="child-section"
         >
           {listItemName}
-          <span>
+          {children && (
             <span>
               <FontAwesomeIcon icon={isExpanded ? faCaretDown : faCaretUp} />
             </span>
-          </span>
+          )}
         </button>
       </h3>
       {isExpanded && <ul id="child-section">{children}</ul>}


### PR DESCRIPTION
[ZH Card](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/1142)