### PR TITLE
Docs/local development

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -6,4 +6,14 @@ SENTRY_RELEASE=<any sentry release tag. 'local_development' or anything can be u
 # It needs to be associated with a service account with write permissions
 GOOGLE_APPLICATION_CREDENTIALS=</Users/user/documents/ggl-cas-storage-localdev.json>
 ATTACHMENTS_BUCKET=<the name of the bucket where to read and store attachments>
+
+# These variables control feature flagging
 GROWTHBOOK_API_KEY=<API key for the growthbook feature flagging service>
+BYPASS_GROWTHBOOK=<true or false>
+
+# This variable allows you to toggle the keycloak login screen on and off
+SHOW_KC_LOGIN=<true or false>
+
+# These variables allow mocking times and authentication during e2e testing
+ENABLE_MOCK_TIME=<true or false>
+ENABLE_MOCK_AUTH=<true or false>

--- a/docs/developer-environment-setup.md
+++ b/docs/developer-environment-setup.md
@@ -1,0 +1,79 @@
+# Setting up the Local Development Environment
+
+## Prerequisites
+
+Ensure the following are installed:
+
+- [Postgres](https://www.postgresql.org/)
+
+## Repository and Version Control
+
+- Ensure you have push access (most likely by being added to the **@bcgov/cas-developers** GitHub team) to [bcgov/cas-cif](https://github.com/bcgov/cas-cif).
+- Ensure you have [GPG commit signing](https://docs.github.com/en/github/authenticating-to-github/signing-commits) set up on your local environment.
+  - First, ensure your `git config user.email` is set to the email address you want to use for signing.
+  - You can verify it's working when you commit to a branch and the signature is indicated by `git log --show-signature`. Once pushed, a "Verified" badge appears next to your commits on GitHub.
+- Clone a local copy of [bcgov/cas-cif](https://github.com/bcgov/cas-cif).
+
+## Install the Dev Tools
+
+In the root of `cas-cif`, run `make install_dev_tools`. This creates the databases, installs packages etc.
+
+To seed the dev data, run `make drop_db && make deploy_dev_data`. If you get warnings about the database being accessed, stop and start postgres (`pg_ctl stop` then `pg_ctl start`).
+
+### Troubleshooting
+
+If you run into an error `failed to start: "No such file or directory"`, this can be caused by the client definition in the global sqitch config. Remove the line `client = path/to/psql` from `~/.sqitch/sqitch.conf`.
+
+There might be an error where postgres is only installed with the `postgres` user and not your local user.
+To address this, in a terminal, enter:
+
+```
+$> sudo -u postgres createuser -s -i -d -r -l -w <<your_local_user>>
+$> sudo -u postgres createdb <<your_local_user>>
+```
+
+## Install Dependencies
+
+Install dependencies with `cd app && yarn install`
+
+## App Environment Variables
+
+Create an `app/.env` file and copy the contents of [`app/.env.example`](../app/.env.example) into it. See the 1Password vault for the values.
+
+## Run the App
+
+Ensure postgres is running (`pg_start` if not). Then run the development server:
+
+```
+cd app && yarn dev
+```
+
+Navigate in your browser to `localhost:3004`.
+
+Work that changes Relay GraphQL queries will require you to re-run `yarn build:relay` (which alternatively can be run using a `--watch` flag).
+
+## Pre-Commit
+
+[pre-commit](https://pre-commit.com/) runs a variety of formatting and lint checks configured in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml) which are required for a pull request to pass CI.
+
+`pre-commit install` will [configure a pre-commit hook to run before every commit](https://pre-commit.com/#usage); alternatively, you can run it manually with:
+
+```
+pre-commit run --all-files
+```
+
+If you are impatient and your work is isolated to Javascript, it may be faster to run only the linter and formatter (`eslint` and `prettier`), but it may not catch everything (such as the end-of-file fixer and trailing whitespace):
+
+```
+yarn lint && yarn format
+```
+
+## Commit Message Conventions
+
+We use [gitlint](https://jorisroovers.com/gitlint/) to check commit message formatting. You can enable it by using `pre-commit install --hook-type commit-msg`.
+
+This project follows the commit message conventions outlined by [Convential Commits](https://www.conventionalcommits.org/). Besides the standard commit types (message prefixes) **feat** and **fix**, we use some other types described there based on the Angular convention; some common ones among those are **test**, **docs**, **chore** and **refactor**. You can find the configuration details in the [.gitlint](../gitlint) file
+
+These facilitate the automated creation of [changelogs](../CHANGELOG.md), using the [standard-version](https://github.com/conventional-changelog/standard-version) utility.
+
+We also extend this prefix convention to the naming of **branches**, eg: `docs/add-readme` or `feat/some-feature`.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -81,7 +81,7 @@ We also extend this prefix convention to the naming of **branches**, eg: `docs/a
 cd app && yarn test
 ```
 
-Front-end unit tests are snapshot-based. Work that changes the DOM will result in a diff from the last accepted snapshot and cause related tests to fail. You can update the snapshots and review / accept the diff with `yarn test -u`.
+Front-end unit tests include snapshots. Work that changes the DOM will result in a diff from the last accepted snapshot and cause related tests to fail. You can update the snapshots and review / accept the diff with `yarn test -u`.
 
 ### Database Unit Tests with pgTAP
 
@@ -108,7 +108,7 @@ cd app && yarn test:e2e
 [Options](https://docs.cypress.io/guides/guides/command-line.html#cypress-run) can be passed to Cypress through this command, for example to run an individual test or subset:
 
 ```
-cd app && yarn test:e2e --spec cypress/integration/accessibility/*
+cd app && yarn test:e2e --spec cypress/integration/cif/*
 ```
 
 ## Growthbook

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,8 +1,115 @@
 # Developer Guidelines
 
-## Setting up the commit-msg hook for the pre-commit
+## Setting up the Local Development Environment
 
-Run `pre-commit install --hook-type commit-msg` to install the commit-msg hook.
+### Prerequisites
+
+Ensure the following are installed:
+
+- [Postgres](https://www.postgresql.org/)
+- [Sqitch](https://sqitch.org/) (requires a working Perl 5 installation)
+- [Node](https://nodejs.org/)
+- [asdf](https://asdf-vm.com/#/core-manage-asdf) (using your system's package manager & follow instructions to add it to your shell)
+
+### Repository and Version Control
+
+- Ensure you have push access (most likely by being added to the **@bcgov/cas-developers** GitHub team) to [bcgov/cas-cif](https://github.com/bcgov/cas-cif).
+- Ensure you have [GPG commit signing](https://docs.github.com/en/github/authenticating-to-github/signing-commits) set up on your local environment.
+  - First, ensure your `git config user.email` is set to the email address you want to use for signing.
+  - You can verify it's working when you commit to a branch and the signature is indicated by `git log --show-signature`. Once pushed, a "Verified" badge appears next to your commits on GitHub.
+- Clone a local copy of [bcgov/cas-cif](https://github.com/bcgov/cas-cif).
+
+### Install the Dev Tools
+
+In the root of `cas-cif`, run `make install_dev_tools`. This creates the databases, installs packages, etc.
+
+To seed the dev data, run `make drop_db && make deploy_dev_data`. If you get warnings about the database being accessed, stop and start postgres (`pg_ctl stop` then `pg_ctl start`).
+
+Install dependencies with `cd app && yarn install`
+
+### App Environment Variables
+
+Create an `app/.env` file and copy the contents of [`app/.env.example`](../app/.env.example) into it. See the 1Password vault for the values.
+
+### Run the App
+
+Ensure postgres is running (`pg_start` if not). Then run the development server:
+
+```
+cd app && yarn dev
+```
+
+Navigate in your browser to `localhost:3004`.
+
+Work that changes Relay GraphQL queries will require you to re-run `yarn build:relay` (which alternatively can be run using a `--watch` flag).
+
+### GraphQL Query Debugger
+
+Graphiql is an interactive in-browser GraphQL IDE available in development at `localhost:3004/graphiql`. It is handy for developing queries interactively before inserting them into a Relay fragment.
+
+### Pre-Commit
+
+[pre-commit](https://pre-commit.com/) runs a variety of formatting and lint checks configured in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml) which are required for a pull request to pass CI.
+
+`pre-commit install` will [configure a pre-commit hook to run before every commit](https://pre-commit.com/#usage); alternatively, you can run it manually with:
+
+```
+pre-commit run --all-files
+```
+
+If you are impatient and your work is isolated to Javascript, it may be faster to run only the linter and formatter (`eslint` and `prettier`), but it may not catch everything (such as the end-of-file fixer and trailing whitespace):
+
+```
+yarn lint && yarn format
+```
+
+### Commit Message Conventions
+
+We use [gitlint](https://jorisroovers.com/gitlint/) to check commit message formatting. You can enable it by using `pre-commit install --hook-type commit-msg`.
+
+This project follows the commit message conventions outlined by [Convential Commits](https://www.conventionalcommits.org/). Besides the standard commit types (message prefixes) **feat** and **fix**, we use some other types described there based on the Angular convention; some common ones among those are **test**, **docs**, **chore** and **refactor**. You can find the configuration details in the [.gitlint](../gitlint) file
+
+These facilitate the automated creation of [changelogs](../CHANGELOG.md), using the [standard-version](https://github.com/conventional-changelog/standard-version) utility.
+
+We also extend this prefix convention to the naming of **branches**, eg: `docs/add-readme` or `feat/some-feature`.
+
+## Testing
+
+### Unit Tests with Jest
+
+```
+cd app && yarn test
+```
+
+Front-end unit tests are snapshot-based. Work that changes the DOM will result in a diff from the last accepted snapshot and cause related tests to fail. You can update the snapshots and review / accept the diff with `yarn test -u`.
+
+### Database Unit Tests with pgTAP
+
+See [Database Testing](#database-testing) below.
+
+### End-to-end Tests with Cypress
+
+#### Run Cypress Specs
+
+First, ensure the web app is running (`cd app && yarn dev`).
+
+For test error debugging and to observe tests' behavior in the browser as they run:
+
+```
+cd app && yarn cypress
+```
+
+To run the tests more efficiently in a headless mode:
+
+```
+cd app && yarn test:e2e
+```
+
+[Options](https://docs.cypress.io/guides/guides/command-line.html#cypress-run) can be passed to Cypress through this command, for example to run an individual test or subset:
+
+```
+cd app && yarn test:e2e --spec cypress/integration/accessibility/*
+```
 
 ## Growthbook
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,77 +1,10 @@
 # Developer Guidelines
 
-## Setting up the Local Development Environment
+(For development environment setup see [`developer-environment-setup`](./developer-environment-setup))
 
-### Prerequisites
-
-Ensure the following are installed:
-
-- [Postgres](https://www.postgresql.org/)
-- [Sqitch](https://sqitch.org/) (requires a working Perl 5 installation)
-- [Node](https://nodejs.org/)
-- [asdf](https://asdf-vm.com/#/core-manage-asdf) (using your system's package manager & follow instructions to add it to your shell)
-
-### Repository and Version Control
-
-- Ensure you have push access (most likely by being added to the **@bcgov/cas-developers** GitHub team) to [bcgov/cas-cif](https://github.com/bcgov/cas-cif).
-- Ensure you have [GPG commit signing](https://docs.github.com/en/github/authenticating-to-github/signing-commits) set up on your local environment.
-  - First, ensure your `git config user.email` is set to the email address you want to use for signing.
-  - You can verify it's working when you commit to a branch and the signature is indicated by `git log --show-signature`. Once pushed, a "Verified" badge appears next to your commits on GitHub.
-- Clone a local copy of [bcgov/cas-cif](https://github.com/bcgov/cas-cif).
-
-### Install the Dev Tools
-
-In the root of `cas-cif`, run `make install_dev_tools`. This creates the databases, installs packages, etc.
-
-To seed the dev data, run `make drop_db && make deploy_dev_data`. If you get warnings about the database being accessed, stop and start postgres (`pg_ctl stop` then `pg_ctl start`).
-
-Install dependencies with `cd app && yarn install`
-
-### App Environment Variables
-
-Create an `app/.env` file and copy the contents of [`app/.env.example`](../app/.env.example) into it. See the 1Password vault for the values.
-
-### Run the App
-
-Ensure postgres is running (`pg_start` if not). Then run the development server:
-
-```
-cd app && yarn dev
-```
-
-Navigate in your browser to `localhost:3004`.
-
-Work that changes Relay GraphQL queries will require you to re-run `yarn build:relay` (which alternatively can be run using a `--watch` flag).
-
-### GraphQL Query Debugger
+## GraphQL Query Debugger
 
 Graphiql is an interactive in-browser GraphQL IDE available in development at `localhost:3004/graphiql`. It is handy for developing queries interactively before inserting them into a Relay fragment.
-
-### Pre-Commit
-
-[pre-commit](https://pre-commit.com/) runs a variety of formatting and lint checks configured in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml) which are required for a pull request to pass CI.
-
-`pre-commit install` will [configure a pre-commit hook to run before every commit](https://pre-commit.com/#usage); alternatively, you can run it manually with:
-
-```
-pre-commit run --all-files
-```
-
-If you are impatient and your work is isolated to Javascript, it may be faster to run only the linter and formatter (`eslint` and `prettier`), but it may not catch everything (such as the end-of-file fixer and trailing whitespace):
-
-```
-yarn lint && yarn format
-```
-
-### Commit Message Conventions
-
-We use [gitlint](https://jorisroovers.com/gitlint/) to check commit message formatting. You can enable it by using `pre-commit install --hook-type commit-msg`.
-
-This project follows the commit message conventions outlined by [Convential Commits](https://www.conventionalcommits.org/). Besides the standard commit types (message prefixes) **feat** and **fix**, we use some other types described there based on the Angular convention; some common ones among those are **test**, **docs**, **chore** and **refactor**. You can find the configuration details in the [.gitlint](../gitlint) file
-
-These facilitate the automated creation of [changelogs](../CHANGELOG.md), using the [standard-version](https://github.com/conventional-changelog/standard-version) utility.
-
-We also extend this prefix convention to the naming of **branches**, eg: `docs/add-readme` or `feat/some-feature`.
 
 ## Testing
 


### PR DESCRIPTION
A couple notes:
- These docs are based on https://github.com/bcgov/cas-ciip-portal/tree/develop/docs, adapted for CIF
- I looked at putting these instructions in the [CAS home repo](https://github.com/bcgov/cas-home/tree/main/docs) but a lot of it ended up being specific to CIF (`make install_dev_tools` takes care of a of what's in the CIIP guide)
- I didn't include anything about `yarn dev --as-role CIF_ADMIN` because we've got bugs
