### PR TITLE
Feat: contact phone and email validation

### DIFF
--- a/app/cypress/integration/cif/contacts.spec.js
+++ b/app/cypress/integration/cif/contacts.spec.js
@@ -58,7 +58,6 @@ describe("The contacts page", () => {
     cy.get("input[aria-label='Family Name']").type("Loblaw");
     cy.get("input[aria-label=Email]").type("bob.loblaw.ca");
     cy.get("input[aria-label='Company Name']").type("ABC");
-
     cy.contains("Changes saved").should("be.visible");
     cy.get("input[aria-label=Phone]").type("12345");
     cy.contains("Changes saved").should("be.visible");

--- a/app/cypress/integration/cif/contacts.spec.js
+++ b/app/cypress/integration/cif/contacts.spec.js
@@ -42,24 +42,8 @@ describe("The contacts page", () => {
     cy.visit("/cif/contacts");
     cy.get("h2").contains("Contacts");
     cy.get("button").contains("Add").click();
-    cy.get("input[aria-label=Email]").type("bob.l001@example.com");
-    cy.contains("Changes saved").should("be.visible");
-    cy.get("button").contains("Submit").click();
-    cy.contains("email already exists").should("be.visible");
-    cy.contains(/please enter a value/i).should("be.visible");
-  });
-
-  it("Validates email and phone number", () => {
-    cy.visit("/cif/contacts");
-    cy.get("h2").contains("Contacts");
-    cy.get("button").contains("Add").click();
-
-    cy.get("input[aria-label='Given Name']").should("be.visible").type("Bob");
-    cy.get("input[aria-label='Family Name']").type("Loblaw");
-    cy.get("input[aria-label=Email]").type("bob.loblaw.ca");
-    cy.get("input[aria-label='Company Name']").type("ABC");
-    cy.contains("Changes saved").should("be.visible");
-    cy.get("input[aria-label=Phone]").type("12345");
+    cy.get("input[aria-label=Email]").type("bob.l001");
+    cy.get("input[aria-label=Phone]").type("1234");
     cy.contains("Changes saved").should("be.visible");
     cy.get("button").contains("Submit").click();
     cy.contains("Please enter in the format: name@example.com").should(
@@ -68,5 +52,10 @@ describe("The contacts page", () => {
     cy.contains(
       "Please enter in a valid phone number format (e.g. 123 456 7890)"
     ).should("be.visible");
+    cy.get("input[aria-label=Email]").type("@example.com");
+    cy.contains("Changes saved").should("be.visible");
+    cy.get("button").contains("Submit").click();
+    cy.contains("email already exists").should("be.visible");
+    cy.contains(/please enter a value/i).should("be.visible");
   });
 });

--- a/app/cypress/integration/cif/contacts.spec.js
+++ b/app/cypress/integration/cif/contacts.spec.js
@@ -49,7 +49,7 @@ describe("The contacts page", () => {
     cy.contains(/please enter a value/i).should("be.visible");
   });
 
-  it("Validates email", () => {
+  it("Validates email and phone number", () => {
     cy.visit("/cif/contacts");
     cy.get("h2").contains("Contacts");
     cy.get("button").contains("Add").click();
@@ -60,31 +60,14 @@ describe("The contacts page", () => {
     cy.get("input[aria-label='Company Name']").type("ABC");
 
     cy.contains("Changes saved").should("be.visible");
-    cy.get("input[aria-label=Phone]").type("1234567890");
-    cy.contains("Changes saved").should("be.visible");
-    cy.get("button").contains("Submit").click();
-    cy.contains("Please enter in the format: name@example.com").should("be.visible");
-    
-  });
-
-  it("Validates phone number", () => {
-    cy.visit("/cif/contacts");
-    cy.get("h2").contains("Contacts");
-    cy.get("button").contains("Add").click();
-
-    cy.get("input[aria-label='Given Name']").should("be.visible").type("Bob");
-    cy.get("input[aria-label='Family Name']").type("Loblaw");
-    cy.get("input[aria-label=Email]").type("bob@loblaw.ca");
-    cy.get("input[aria-label='Company Name']").type("ABC");
-
-    cy.contains("Changes saved").should("be.visible");
     cy.get("input[aria-label=Phone]").type("12345");
     cy.contains("Changes saved").should("be.visible");
-
     cy.get("button").contains("Submit").click();
-    cy.contains("Please enter in a valid phone number format (e.g. 123 456 7890)").should("be.visible");
+    cy.contains("Please enter in the format: name@example.com").should(
+      "be.visible"
+    );
+    cy.contains(
+      "Please enter in a valid phone number format (e.g. 123 456 7890)"
+    ).should("be.visible");
   });
-  
 });
-
-

--- a/app/cypress/integration/cif/contacts.spec.js
+++ b/app/cypress/integration/cif/contacts.spec.js
@@ -48,4 +48,43 @@ describe("The contacts page", () => {
     cy.contains("email already exists").should("be.visible");
     cy.contains(/please enter a value/i).should("be.visible");
   });
+
+  it("Validates email", () => {
+    cy.visit("/cif/contacts");
+    cy.get("h2").contains("Contacts");
+    cy.get("button").contains("Add").click();
+
+    cy.get("input[aria-label='Given Name']").should("be.visible").type("Bob");
+    cy.get("input[aria-label='Family Name']").type("Loblaw");
+    cy.get("input[aria-label=Email]").type("bob.loblaw.ca");
+    cy.get("input[aria-label='Company Name']").type("ABC");
+
+    cy.contains("Changes saved").should("be.visible");
+    cy.get("input[aria-label=Phone]").type("1234567890");
+    cy.contains("Changes saved").should("be.visible");
+    cy.get("button").contains("Submit").click();
+    cy.contains("Please enter in the format: name@example.com").should("be.visible");
+    
+  });
+
+  it("Validates phone number", () => {
+    cy.visit("/cif/contacts");
+    cy.get("h2").contains("Contacts");
+    cy.get("button").contains("Add").click();
+
+    cy.get("input[aria-label='Given Name']").should("be.visible").type("Bob");
+    cy.get("input[aria-label='Family Name']").type("Loblaw");
+    cy.get("input[aria-label=Email]").type("bob@loblaw.ca");
+    cy.get("input[aria-label='Company Name']").type("ABC");
+
+    cy.contains("Changes saved").should("be.visible");
+    cy.get("input[aria-label=Phone]").type("12345");
+    cy.contains("Changes saved").should("be.visible");
+
+    cy.get("button").contains("Submit").click();
+    cy.contains("Please enter in a valid phone number format (e.g. 123 456 7890)").should("be.visible");
+  });
+  
 });
+
+

--- a/app/data/jsonSchemaForm/contactSchema.ts
+++ b/app/data/jsonSchemaForm/contactSchema.ts
@@ -19,7 +19,8 @@ const contactSchema = {
     phone: {
       type: "string",
       title: "Phone",
-      pattern: "^\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}$",
+      pattern:
+        "^(\\+?\\d{1,2}[\\s,-]?)?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}$",
     },
     phoneExt: {
       type: "string",

--- a/app/data/jsonSchemaForm/contactSchema.ts
+++ b/app/data/jsonSchemaForm/contactSchema.ts
@@ -14,10 +14,12 @@ const contactSchema = {
     email: {
       type: "string",
       title: "Email",
+      pattern: "^[\\.\\w-]+@([\\w-]+\\.)+[\\w-]{2,4}$",
     },
     phone: {
       type: "string",
       title: "Phone",
+      pattern: "^\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}$",
     },
     phoneExt: {
       type: "string",

--- a/app/data/jsonSchemaForm/customFormats.ts
+++ b/app/data/jsonSchemaForm/customFormats.ts
@@ -5,8 +5,12 @@
 
 export const customFormats = {
   rfpDigits: /\d{3,4}/,
+  email: /^[\.\w-]+@([\w-]+\.)+[\w-]{2,4}$/,
+  phone: /^\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/,
 };
 
 export const customFormatsErrorMessages = {
   rfpDigits: "Please enter 3 or 4 digits for the random RFP digits",
+  email: "Please enter in the format: name@example.com",
+  phone: "Please enter in a valid phone number format (e.g. 1 234 567 8909)",
 };

--- a/app/data/jsonSchemaForm/customFormats.ts
+++ b/app/data/jsonSchemaForm/customFormats.ts
@@ -6,11 +6,11 @@
 export const customFormats = {
   rfpDigits: /\d{3,4}/,
   email: /^[\.\w-]+@([\w-]+\.)+[\w-]{2,4}$/,
-  phone: /^\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/,
+  phone: /^(\+?\d{1,2}[\s,-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/,
 };
 
 export const customFormatsErrorMessages = {
   rfpDigits: "Please enter 3 or 4 digits for the random RFP digits",
   email: "Please enter in the format: name@example.com",
-  phone: "Please enter in a valid phone number format (e.g. 1 234 567 8909)",
+  phone: "Please enter in a valid phone number format (e.g. 123 456 7890)",
 };

--- a/app/lib/theme/customTransformErrors.ts
+++ b/app/lib/theme/customTransformErrors.ts
@@ -8,12 +8,22 @@ export const customTransformErrors = (
   return errors
     .filter((error) => error.name !== "oneOf")
     .map((error) => {
-      if (!["format", "required"].includes(error.name)) return error;
+      if (!["format", "required", "pattern"].includes(error.name)) return error;
       if (error.name === "required")
         return {
           ...error,
           message: `Please enter a value`,
         };
+      if (
+        error.name === "pattern" &&
+        // substring is necessary here as the properties include a "." prefix. eg. the property for the email field is ".email"
+        customFormatsErrorMessages[error.property.substring(1)]
+      ) {
+        return {
+          ...error,
+          message: customFormatsErrorMessages[error.property.substring(1)],
+        };
+      }
       if (customFormatsErrorMessages[error.params.format])
         return {
           ...error,

--- a/app/server/middleware/graphql/validateRecord.ts
+++ b/app/server/middleware/graphql/validateRecord.ts
@@ -3,6 +3,8 @@ import Ajv, { ErrorObject } from "ajv";
 const ajv = new Ajv({ allErrors: true });
 // AJV needs to be made aware of any custom formats used in the schema
 ajv.addFormat("rfpDigits", /\d{3,4}/);
+ajv.addFormat("email", /^[\.\w-]+@([\w-]+\.)+[\w-]{2,4}$/);
+ajv.addFormat("phone", /^?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/);
 
 const validateRecord: (schema: any, formData: any) => ErrorObject[] = (
   schema,

--- a/app/server/middleware/graphql/validateRecord.ts
+++ b/app/server/middleware/graphql/validateRecord.ts
@@ -4,7 +4,10 @@ const ajv = new Ajv({ allErrors: true });
 // AJV needs to be made aware of any custom formats used in the schema
 ajv.addFormat("rfpDigits", /\d{3,4}/);
 ajv.addFormat("email", /^[\.\w-]+@([\w-]+\.)+[\w-]{2,4}$/);
-ajv.addFormat("phone", /^?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/);
+ajv.addFormat(
+  "phone",
+  /^(\+?\d{1,2}[\s,-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/
+);
 
 const validateRecord: (schema: any, formData: any) => ErrorObject[] = (
   schema,


### PR DESCRIPTION
- Added regex for phone number and email addresses, with custom validation error messages.
- Enforced the patterns on their respective fields in the `contractSchema`
