### PR TITLE
Chore: pgo artifactory images

### DIFF
--- a/chart/cas-cif/templates/cronJobs/test-database-backups.yaml
+++ b/chart/cas-cif/templates/cronJobs/test-database-backups.yaml
@@ -45,7 +45,7 @@ spec:
                 set -euo pipefail;
                 declare -i VALUE;
                 export PGPASSWORD="$(CIF_BACKUP_PASS)";
-                VALUE=$(psql -U postgres -h "$(CIF_BACKUP_HOST)" -qtAX -d $(CIF_BACKUP_DATABASE) -c "select count(*) from cif_private.full_backup_log where full_backup_timestamp > now() - interval '12 hours'");
+                VALUE=$(psql -U postgres -h ${CIF_BACKUP_HOST} -qtAX -d ${CIF_BACKUP_DATABASE} -c "select count(*) from cif_private.full_backup_log where full_backup_timestamp > now() - interval '12 hours'");
                 if [[ $VALUE -lt 1 ]] ; then
                   echo 'no timestamp found'
                   exit 1

--- a/chart/cas-cif/templates/postgres.yaml
+++ b/chart/cas-cif/templates/postgres.yaml
@@ -8,6 +8,7 @@ metadata:
     postgres-operator.crunchydata.com/pgbackrest-restore: {{ now | date "2006-01-02 15:04:05.000000" | quote }}
   {{- end }}
 spec:
+  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:centos8-14.1-0
   metadata:
     labels: {{ include "cas-cif.labels" . | nindent 6 }}
   postgresVersion: 14
@@ -47,6 +48,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   proxy:
     pgBouncer:
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:centos8-1.16-0
       resources:
         requests:
           cpu: 10m

--- a/database_backup_test/backup-test/templates/postgres.yaml
+++ b/database_backup_test/backup-test/templates/postgres.yaml
@@ -86,8 +86,7 @@ spec:
         enabled: true
         repoName: repo1
         options:
-        - --type=time
-        - --target={{ now | date_modify "-1h" | date "2006-01-02 15:04:05.000000" | quote }}
+        - --type=immediate
         - --archive-mode=off
     {{- end }}
       configuration:

--- a/database_backup_test/backup-test/templates/postgres.yaml
+++ b/database_backup_test/backup-test/templates/postgres.yaml
@@ -8,6 +8,7 @@ metadata:
     postgres-operator.crunchydata.com/pgbackrest-restore: {{ now | date "2006-01-02 15:04:05.000000" | quote }}
   {{- end }}
 spec:
+  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:centos8-14.1-0
   metadata:
     labels: {{ include "backup-test.labels" . | nindent 6 }}
   postgresVersion: 14
@@ -47,6 +48,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   proxy:
     pgBouncer:
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:centos8-1.16-0
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
Use images in artifactory for the Postgres Operator, fixes an image-pull error when using the crunchy hosted images
plus a couple of tweaks to the db backup tests