### PR TITLE
chore: use artifactory image for crunchy monitoring exporter

### DIFF
--- a/chart/cas-cif/templates/postgres.yaml
+++ b/chart/cas-cif/templates/postgres.yaml
@@ -113,6 +113,7 @@ spec:
   monitoring:
     pgmonitor:
       exporter:
+        image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-exporter:ubi8-5.0.4-0
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
missed one image for the monitoring exporter