### PR TITLE
Chore: remove directory from uninstall command

### DIFF
--- a/chart/cas-cif/templates/cronJobs/test-database-backups.yaml
+++ b/chart/cas-cif/templates/cronJobs/test-database-backups.yaml
@@ -69,4 +69,4 @@ spec:
             - -c
             - |
                 set -euo pipefail;
-                helm uninstall -n {{ include "cas-cif.namespacePrefix" . }}-tools backup-test ./backup-test;
+                helm uninstall -n {{ include "cas-cif.namespacePrefix" . }}-tools backup-test;

--- a/chart/cas-cif/templates/cronJobs/test-database-backups.yaml
+++ b/chart/cas-cif/templates/cronJobs/test-database-backups.yaml
@@ -69,4 +69,5 @@ spec:
             - -c
             - |
                 set -euo pipefail;
+                echo 'timestamp found, backup ok...uninstalling test cluster';
                 helm uninstall -n {{ include "cas-cif.namespacePrefix" . }}-tools backup-test;

--- a/database_backup_test/backup-test/templates/postgres.yaml
+++ b/database_backup_test/backup-test/templates/postgres.yaml
@@ -83,6 +83,7 @@ spec:
         - cif
   backups:
     pgbackrest:
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:centos8-2.36-0
     {{- if .Values.db.restore.enabled }}
       restore:
         enabled: true


### PR DESCRIPTION
had an unnecessary directory in the command that was causing noise in the output