### PR TITLE
Fix actual performance milestone calculation

### DIFF
--- a/app/components/Form/ProjectEmissionIntensityReportForm.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportForm.tsx
@@ -209,8 +209,9 @@ const ProjectEmissionsIntensityReport: React.FC<Props> = (props) => {
     actualPerformanceMilestoneAmount = null;
   } else {
     actualPerformanceMilestoneAmount =
-      Number(maximumPerformanceMilestoneAmount ?? null) *
-      Number(paymentPercentageOfPerformanceMilestoneAmount ?? null);
+      (Number(maximumPerformanceMilestoneAmount ?? null) *
+        Number(paymentPercentageOfPerformanceMilestoneAmount ?? null)) /
+      100;
   }
 
   // Mutations

--- a/app/tests/unit/components/Form/ProjectEmissionIntensityReportForm.test.tsx
+++ b/app/tests/unit/components/Form/ProjectEmissionIntensityReportForm.test.tsx
@@ -200,7 +200,7 @@ describe("the emission intensity report form component", () => {
     ).toHaveTextContent("$100");
     expect(
       screen.getByLabelText("Actual Performance Milestone Amount")
-    ).toHaveTextContent("$6,000.00");
+    ).toHaveTextContent("$60.00");
     expect(
       screen.getByLabelText(/Date invoice sent to CSNR/i)
     ).toHaveTextContent(/Feb[.]? 11, 2022/);


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-cif/issues/1442

I'm not sure why there's a happo diff on [IA Project funding agreement Form](https://happo.io/a/336/p/1010/compare/1d1c42e0bea21c11e4cd2f095751cef26df30f22/bf860fad2146ec1d35140d99f8a70f2320a7d64e?t=diffs&target=chrome-laptop#IA%5C%20Project%5C%20funding%5C%20agreement%5C%20Form). However, the "Total Project Payment Amount to Date" calculation isn't completed yet ([card to finish it here](https://github.com/bcgov/cas-cif/issues/1442)), so probably not worth worrying about diffs at this stage since either placeholder is acceptable at this point.