### PR TITLE
Update e2e testing in dev docs

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -27,6 +27,7 @@ See [Database Testing](#database-testing) below.
 First, ensure the web app is running (`cd app && yarn dev`).
 
 For faster performance, build and run the app:
+
 ```
 yarn build && yarn start
 ```
@@ -40,6 +41,7 @@ cd app && yarn cypress
 To run the tests more efficiently in a headless mode:
 
 Ensure Happo apiKey and apiSecret are commented out of your .env
+
 ```
 cd app && yarn build yarn test:e2e
 ```

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -26,6 +26,11 @@ See [Database Testing](#database-testing) below.
 
 First, ensure the web app is running (`cd app && yarn dev`).
 
+For faster performance, build and run the app:
+```
+yarn build && yarn start
+```
+
 For test error debugging and to observe tests' behavior in the browser as they run:
 
 ```
@@ -34,8 +39,9 @@ cd app && yarn cypress
 
 To run the tests more efficiently in a headless mode:
 
+Ensure Happo apiKey and apiSecret are commented out of your .env
 ```
-cd app && yarn test:e2e
+cd app && yarn build yarn test:e2e
 ```
 
 [Options](https://docs.cypress.io/guides/guides/command-line.html#cypress-run) can be passed to Cypress through this command, for example to run an individual test or subset:


### PR DESCRIPTION
No Card

A very small update to the developer guide for running e2e tests in headless mode