### PR TITLE
chore: replace deprecated reporting requirement staging function

### DIFF
--- a/app/components/Form/ProjectAnnualReportForm.tsx
+++ b/app/components/Form/ProjectAnnualReportForm.tsx
@@ -20,14 +20,13 @@ import {
   addReportFormChange,
   deleteReportFormChange,
   getSortedReports,
-  stageReportFormChanges,
   updateReportFormChange,
 } from "./Functions/reportingRequirementFormChangeFunctions";
 import SavingIndicator from "./SavingIndicator";
 import UndoChangesButton from "./UndoChangesButton";
 import ReportGenerator from "components/ReportingRequirement/ReportGenerator";
 import { useGenerateAnnualReports } from "mutations/ProjectReportingRequirement/generateAnnualReports";
-
+import stageMultipleReportingRequirementFormChanges from "./Functions/stageMultipleReportingRequirementFormChanges";
 interface Props {
   onSubmit: () => void;
   projectRevision: ProjectAnnualReportForm_projectRevision$key;
@@ -285,7 +284,7 @@ const ProjectAnnualReportForm: React.FC<Props> = (props) => {
         size="medium"
         variant="primary"
         onClick={() =>
-          stageReportFormChanges(
+          stageMultipleReportingRequirementFormChanges(
             applyStageFormChangeMutation,
             props.onSubmit,
             formRefs,

--- a/app/components/Form/ProjectFundingAgreementForm.tsx
+++ b/app/components/Form/ProjectFundingAgreementForm.tsx
@@ -17,9 +17,9 @@ import { ProjectFundingAgreementForm_projectRevision$key } from "__generated__/P
 import { ProjectFundingAgreementForm_query$key } from "__generated__/ProjectFundingAgreementForm_query.graphql";
 import AdditionalFundingSourcesArrayFieldTemplate from "./AdditionalFundingSourcesArrayFieldTemplate";
 import FormBase from "./FormBase";
-import { stageReportFormChanges } from "./Functions/reportingRequirementFormChangeFunctions";
 import SavingIndicator from "./SavingIndicator";
 import UndoChangesButton from "./UndoChangesButton";
+import stageMultipleReportingRequirementFormChanges from "./Functions/stageMultipleReportingRequirementFormChanges";
 
 interface Props {
   query: ProjectFundingAgreementForm_query$key;
@@ -347,13 +347,12 @@ const ProjectFundingAgreementForm: React.FC<Props> = (props) => {
           <Button
             type="submit"
             onClick={() =>
-              stageReportFormChanges(
-                () => {},
+              stageMultipleReportingRequirementFormChanges(
+                stageFormChange,
                 props.onSubmit,
                 formRefs,
                 [...projectRevision.projectFundingAgreementFormChanges.edges],
-                null,
-                stageFormChange
+                null
               )
             }
             style={{ marginRight: "1rem" }}


### PR DESCRIPTION
Exploratory work done regarding card [1564](https://github.com/bcgov/cas-cif/issues/1564)

Looks like the deprecated function can be swapped very simply.