### PR TITLE
chore: change sort order of report due date

### DIFF
--- a/app/components/Project/ProjectMilestoneDue.tsx
+++ b/app/components/Project/ProjectMilestoneDue.tsx
@@ -14,7 +14,7 @@ const ProjectMilestoneDue: React.FC<Props> = ({ project }) => {
         fragment ProjectMilestoneDue_project on Project {
           nextMilestoneDueDate
           latestCompletedReportingRequirements: reportingRequirementsByProjectId(
-            orderBy: REPORT_DUE_DATE_ASC
+            orderBy: REPORT_DUE_DATE_DESC
             filter: {
               submittedDate: { isNull: false }
               reportTypeByReportType: { isMilestone: { equalTo: true } }


### PR DESCRIPTION
Addressing a bug (reported  in Teams) where completed milestones were showing up as late in the projects table under 'Milestone Due' column.