### PR TITLE
fix: show emission intensity data on view mode

### DIFF
--- a/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
@@ -155,7 +155,7 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
     return null;
 
   if (
-    allFormChangesPristine ||
+    (allFormChangesPristine && !viewOnly) ||
     (!summaryReportingRequirement && !summaryEmissionIntensityReport)
   )
     return (
@@ -177,6 +177,7 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
       )}
       {/* Show this part if none of the emission intensity report form properties have been updated */}
       {allFormChangesPristine &&
+        !viewOnly &&
         summaryEmissionIntensityReport?.operation !== "ARCHIVE" && (
           <FormNotAddedOrUpdated
             isFirstRevision={isFirstRevision}


### PR DESCRIPTION
Addressing a bug (reported in Teams) -> "Missing" Emissions info

[ZH CARD 1647](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-cif/1647)