### PR TITLE
Fix: 1651 not using hardcoded rfp ID

### DIFF
--- a/app/components/Form/ApplicationOverviewForm.tsx
+++ b/app/components/Form/ApplicationOverviewForm.tsx
@@ -82,7 +82,6 @@ const ApplicationOverviewForm: React.FC<Props> = (props) => {
     proposalReference: (Math.random() * 1000).toString(),
     summary: "This is a summary of the project",
     operatorId: 1,
-    fundingStreamRfpId: 1,
     comments: "some amendment comment",
     contractNumber: "654321",
     totalFundingRequest: 1000,

--- a/app/tests/unit/components/Form/ApplicationOverviewForm.test.tsx
+++ b/app/tests/unit/components/Form/ApplicationOverviewForm.test.tsx
@@ -93,7 +93,7 @@ describe("The Application Overview Form", () => {
             newFormData: {
               projectName: "projectynew",
               legalName: "legaly",
-              fundingStreamRfpId: 1,
+              fundingStreamRfpId: 7,
               proposalReference: expect.anything(),
               summary: expect.anything(),
               operatorId: expect.anything(),
@@ -140,7 +140,7 @@ describe("The Application Overview Form", () => {
         rowId: 999,
         formChangePatch: {
           newFormData: {
-            fundingStreamRfpId: 1,
+            fundingStreamRfpId: 7,
             projectName: "projecty",
             legalName: "legaly",
             proposalReference: expect.anything(),


### PR DESCRIPTION
[ZH CARD 1651](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-cif/1651)