### PR TITLE
Hotfix: fix incorrect integer casts

### DIFF
--- a/schema/deploy/computed_columns/project_revision_total_project_value.sql
+++ b/schema/deploy/computed_columns/project_revision_total_project_value.sql
@@ -16,7 +16,7 @@ with additional_funding_sources as
         and fc.form_data_table_name = 'funding_parameter'
         and operation != 'archive'
         )::jsonb
-      ) as x(source text, amount int, status text)
+      ) as x(source text, amount numeric, status text)
     )
   select
     (

--- a/schema/deploy/functions/handle_funding_parameter_form_change_commit.sql
+++ b/schema/deploy/functions/handle_funding_parameter_form_change_commit.sql
@@ -36,11 +36,11 @@ begin
     project_assets_life_end_date)
   values(
     (select form_data_record_id from cif.form_change where form_data_table_name = 'project' and project_revision_id = $1.project_revision_id),
-    (fc.new_form_data->>'maxFundingAmount')::int,
-    (fc.new_form_data->>'provinceSharePercentage')::int,
-    (fc.new_form_data->>'holdbackPercentage')::int,
-    (fc.new_form_data->>'anticipatedFundingAmount')::int,
-    (fc.new_form_data->>'proponentCost')::int,
+    (fc.new_form_data->>'maxFundingAmount')::numeric,
+    (fc.new_form_data->>'provinceSharePercentage')::numeric,
+    (fc.new_form_data->>'holdbackPercentage')::numeric,
+    (fc.new_form_data->>'anticipatedFundingAmount')::numeric,
+    (fc.new_form_data->>'proponentCost')::numeric,
     (fc.new_form_data->>'contractStartDate')::timestamptz,
     (fc.new_form_data->>'projectAssetsLifeEndDate')::timestamptz
   ) returning id into funding_parameter_record_id;
@@ -56,7 +56,7 @@ begin
     (select form_data_record_id from cif.form_change where form_data_table_name = 'project' and project_revision_id = $1.project_revision_id),
     (value::jsonb->>'status'),
     (value::jsonb->>'source'),
-    (value::jsonb->>'amount')::int,
+    (value::jsonb->>'amount')::numeric,
     row_number () over ()
   from jsonb_array_elements(($1.new_form_data->>'additionalFundingSources')::jsonb);
 
@@ -68,11 +68,11 @@ begin
   elsif fc.operation = 'update' then
 
   update cif.funding_parameter fp set
-    max_funding_amount = (fc.new_form_data->>'maxFundingAmount')::int,
-    province_share_percentage = (fc.new_form_data->>'provinceSharePercentage')::int,
-    holdback_percentage = (fc.new_form_data->>'holdbackPercentage')::int,
-    anticipated_funding_amount = (fc.new_form_data->>'anticipatedFundingAmount')::int,
-    proponent_cost = (fc.new_form_data->>'proponentCost')::int,
+    max_funding_amount = (fc.new_form_data->>'maxFundingAmount')::numeric,
+    province_share_percentage = (fc.new_form_data->>'provinceSharePercentage')::numeric,
+    holdback_percentage = (fc.new_form_data->>'holdbackPercentage')::numeric,
+    anticipated_funding_amount = (fc.new_form_data->>'anticipatedFundingAmount')::numeric,
+    proponent_cost = (fc.new_form_data->>'proponentCost')::numeric,
     contract_start_date = (fc.new_form_data->>'contractStartDate')::timestamptz,
     project_assets_life_end_date =(fc.new_form_data->>'projectAssetsLifeEndDate')::timestamptz
   where fp.id = fc.form_data_record_id;
@@ -100,7 +100,7 @@ begin
     (select form_data_record_id from cif.form_change where form_data_table_name = 'project' and project_revision_id = $1.project_revision_id),
     (value::jsonb->>'status'),
     (value::jsonb->>'source'),
-    (value::jsonb->>'amount')::int,
+    (value::jsonb->>'amount')::numeric,
     row_number () over ()
   from jsonb_array_elements(($1.new_form_data->>'additionalFundingSources')::jsonb)
   on conflict(project_id, source_index) where archived_at is null do update set

--- a/schema/test/unit/functions/handle_funding_parameter_form_change_commit_test.sql
+++ b/schema/test/unit/functions/handle_funding_parameter_form_change_commit_test.sql
@@ -39,32 +39,32 @@ insert into cif.project_revision(id, change_status, project_id)
     (2, 'pending', 2);
 
 select cif.create_form_change('create', 'funding_parameter_EP', 'cif', 'funding_parameter', '{}', 7, null, 'staged', '[]');
-select cif.create_form_change('update', 'funding_parameter_IA', 'cif', 'funding_parameter', '{"anticipatedFundingAmount": 5}', null, null, 'committed', '[]');
+select cif.create_form_change('update', 'funding_parameter_IA', 'cif', 'funding_parameter', '{"anticipatedFundingAmount": 5.5}', null, null, 'committed', '[]');
 
 
 select cif.create_form_change('create', 'funding_parameter_EP', 'cif', 'funding_parameter',
   '{
     "projectId":1,
-    "holdbackPercentage":10,
-    "provinceSharePercentage":50,
+    "holdbackPercentage":10.5,
+    "provinceSharePercentage":50.5,
     "contractStartDate":"2023-03-09T23:59:59.999-08:00",
     "projectAssetsLifeEndDate":"2023-03-25T23:59:59.999-07:00",
-    "maxFundingAmount":500,
-    "proponentCost":5,
-    "anticipatedFundingAmount":55,
-    "additionalFundingSources":[{"source":"oldEPsource1","amount":555,"status":"Awaiting Approval"},{"source":"oldEPsource2","amount":666,"status":"Approved"}]
+    "maxFundingAmount":500.5,
+    "proponentCost":5.5,
+    "anticipatedFundingAmount":55.5,
+    "additionalFundingSources":[{"source":"oldEPsource1","amount":555.5,"status":"Awaiting Approval"},{"source":"oldEPsource2","amount":666.6,"status":"Approved"}]
   }', null, 1, 'staged', '[]');
 
 select cif.create_form_change('create', 'funding_parameter_IA', 'cif', 'funding_parameter',
   '{
        "projectId":2,
-       "provinceSharePercentage":50,
+       "provinceSharePercentage":50.5,
        "additionalFundingSources":[{"source":"oldIAsource","amount":1,"status":"Awaiting Approval"}],
-       "maxFundingAmount":100,
-       "proponentCost":10,
+       "maxFundingAmount":100.5,
+       "proponentCost":10.5,
        "contractStartDate":"2023-03-09T23:59:59.999-08:00",
        "projectAssetsLifeEndDate":"2023-03-24T23:59:59.999-07:00",
-       "anticipatedFundingAmount":10
+       "anticipatedFundingAmount":10.5
   }', null, 2, 'staged', '[]');
 
 
@@ -115,13 +115,13 @@ select results_eq(
   $$,
   $$
   values (
-        10::numeric,
-        50::numeric,
+        10.5::numeric,
+        50.5::numeric,
         '2023-03-09T23:59:59.999-08:00'::timestamptz,
         '2023-03-25T23:59:59.999-07:00'::timestamptz,
-        500::numeric,
-        5::numeric,
-        55::numeric
+        500.5::numeric,
+        5.5::numeric,
+        55.5::numeric
   )
   $$,
   'The correct EP values were added to the funding_parameter table on create'
@@ -136,13 +136,13 @@ select results_eq(
   $$
   values (
     'oldEPsource1'::varchar,
-    555::numeric,
+    555.5::numeric,
     'Awaiting Approval'::varchar,
     1
   ),
   (
     'oldEPsource2'::varchar,
-    666::numeric,
+    666.6::numeric,
     'Approved'::varchar,
     2
   )
@@ -160,12 +160,12 @@ select results_eq(
   $$,
   $$
   values (
-        50::numeric,
+        50.5::numeric,
         '2023-03-09T23:59:59.999-08:00'::timestamptz,
         '2023-03-24T23:59:59.999-07:00'::timestamptz,
-        100::numeric,
-        10::numeric,
-        10::numeric
+        100.5::numeric,
+        10.5::numeric,
+        10.5::numeric
   )
   $$,
   'The correct IA values were added to the funding_parameter table on create'
@@ -206,25 +206,25 @@ select cif.create_form_change('update', 'project', 'cif', 'project', '{}', 2, 4,
 select cif.create_form_change('update', 'funding_parameter_EP', 'cif', 'funding_parameter',
   '{
     "projectId":1,
-    "holdbackPercentage":7,
-    "provinceSharePercentage":7,
+    "holdbackPercentage":7.5,
+    "provinceSharePercentage":7.5,
     "contractStartDate":"2027-03-09T23:59:59.999-08:00",
     "projectAssetsLifeEndDate":"2027-03-25T23:59:59.999-07:00",
-    "maxFundingAmount":7,
-    "proponentCost":5,
-    "anticipatedFundingAmount":55,
+    "maxFundingAmount":7.5,
+    "proponentCost":5.5,
+    "anticipatedFundingAmount":55.5,
     "additionalFundingSources":[{"source":"newEPsource1","amount":7,"status":"Awaiting Approval"}]
   }', 1, 3, 'staged', '[]');
   select cif.create_form_change('update', 'funding_parameter_IA', 'cif', 'funding_parameter',
   '{
     "projectId":1,
-    "provinceSharePercentage":9,
+    "provinceSharePercentage":9.5,
     "contractStartDate":"2029-03-09T23:59:59.999-08:00",
     "projectAssetsLifeEndDate":"2029-03-25T23:59:59.999-07:00",
-    "maxFundingAmount":9,
-    "proponentCost":5,
-    "anticipatedFundingAmount":55,
-    "additionalFundingSources":[{"source":"iasource","amount":11,"status":"Awaiting Approval"}, {"source":"iasource2","amount":22,"status":"Awaiting Approval"}, {"source":"iasource3","amount":33,"status":"Awaiting Approval"}]
+    "maxFundingAmount":9.5,
+    "proponentCost":5.5,
+    "anticipatedFundingAmount":55.5,
+    "additionalFundingSources":[{"source":"iasource","amount":11.5,"status":"Awaiting Approval"}, {"source":"iasource2","amount":22,"status":"Awaiting Approval"}, {"source":"iasource3","amount":33.5,"status":"Awaiting Approval"}]
   }', 2, 4, 'staged', '[]');
 
 -- EP projects
@@ -237,13 +237,13 @@ select results_eq(
   $$,
   $$
   values (
-        7::numeric,
-        7::numeric,
+        7.5::numeric,
+        7.5::numeric,
         '2027-03-09T23:59:59.999-08:00'::timestamptz,
         '2027-03-25T23:59:59.999-07:00'::timestamptz,
-        7::numeric,
-        5::numeric,
-        55::numeric
+        7.5::numeric,
+        5.5::numeric,
+        55.5::numeric
   )
   $$,
   'The correct EP values were updated in the funding_parameter table on update'
@@ -280,12 +280,12 @@ select results_eq(
   $$,
   $$
   values (
-        9::numeric,
+        9.5::numeric,
         '2029-03-09T23:59:59.999-08:00'::timestamptz,
         '2029-03-25T23:59:59.999-07:00'::timestamptz,
-        9::numeric,
-        5::numeric,
-        55::numeric
+        9.5::numeric,
+        5.5::numeric,
+        55.5::numeric
   )
   $$,
   'The correct IA values were added to the funding_parameter table on update'
@@ -300,7 +300,7 @@ select results_eq(
   $$
   values (
     'iasource'::varchar,
-    11::numeric,
+    11.5::numeric,
     'Awaiting Approval'::varchar,
     1
   ),
@@ -312,7 +312,7 @@ select results_eq(
   ),
   (
     'iasource3'::varchar,
-    33::numeric,
+    33.5::numeric,
     'Awaiting Approval'::varchar,
     3
   )


### PR DESCRIPTION
There were some functions that were incorrectly casting numeric values to integers, which was preventing users from submitting funded projects along with some other unintended behaviour.