### PR TITLE
fix: showing `not added` when project status and operator not filled out

### DIFF
--- a/app/components/Form/ProjectForm.tsx
+++ b/app/components/Form/ProjectForm.tsx
@@ -61,12 +61,16 @@ export const createProjectUiSchema = (
     operatorId: {
       "ui:placeholder": "Select an Operator",
       "ui:widget": "SearchWidget",
-      "ui:options": {
-        text: `${
-          (legalName ? `${legalName}` : "") +
-          (bcRegistryId ? ` (${bcRegistryId})` : "")
-        }`,
-      },
+      ...(legalName || bcRegistryId
+        ? {
+            "ui:options": {
+              text: `${
+                (legalName ? `${legalName}` : "") +
+                (bcRegistryId ? ` (${bcRegistryId})` : "")
+              }`,
+            },
+          }
+        : {}),
     },
     fundingStreamRfpId: {
       "ui:widget": "SelectRfpWidget",
@@ -78,9 +82,7 @@ export const createProjectUiSchema = (
     projectStatusId: {
       "ui:placeholder": "Select a Project Status",
       "ui:widget": "SearchWidget",
-      "ui:options": {
-        text: `${projectStatus}`,
-      },
+      ...(projectStatus ? { "ui:options": { text: projectStatus } } : {}),
     },
     sectorName: {
       "ui:placeholder": "Select a Sector",


### PR DESCRIPTION
[ZH CARD 805](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-cif/805)

Note: Operator ID had the same issue which is not mentioned in the card itself but got fixed in this PR.