### PR TITLE
Fix: 1707 change obsolete images for PGO in backup test chart

### DIFF
--- a/database_backup_test/backup-test/templates/postgres.yaml
+++ b/database_backup_test/backup-test/templates/postgres.yaml
@@ -8,7 +8,7 @@ metadata:
     postgres-operator.crunchydata.com/pgbackrest-restore: {{ now | date "2006-01-02 15:04:05.000000" | quote }}
   {{- end }}
 spec:
-  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:centos8-14.1-0
+  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:ubi8-14.7-0
   metadata:
     labels: {{ include "backup-test.labels" . | nindent 6 }}
   postgresVersion: 14
@@ -48,7 +48,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   proxy:
     pgBouncer:
-      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:centos8-1.16-0
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:ubi8-1.18-0
       resources:
         requests:
           cpu: 10m
@@ -83,7 +83,7 @@ spec:
         - cif
   backups:
     pgbackrest:
-      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:centos8-2.36-0
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.41-4
     {{- if .Values.db.restore.enabled }}
       restore:
         enabled: true


### PR DESCRIPTION
[ZH CARD 1707](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-cif/1707)