### PR TITLE
Fix: 1808 shows secondary contacts in project contact summary form

### DIFF
--- a/app/components/Form/ProjectContactFormSummary.tsx
+++ b/app/components/Form/ProjectContactFormSummary.tsx
@@ -113,9 +113,7 @@ const ProjectContactFormSummary: React.FC<Props> = ({
   const secondaryContacts = useMemo(
     () =>
       contactFormChanges.filter(
-        ({ node }) =>
-          node.newFormData?.contactIndex !== 1 &&
-          (node.isPristine === false || node.isPristine === null)
+        ({ node }) => node.newFormData?.contactIndex !== 1
       ),
     [contactFormChanges]
   );
@@ -150,6 +148,7 @@ const ProjectContactFormSummary: React.FC<Props> = ({
 
   const contactsJSX = useMemo(() => {
     return secondaryContacts.map(({ node }) => {
+      if (node.isPristine && renderDiff) return null;
       const latestCommittedContactNode = lastCommittedSecondaryContacts.find(
         (latestCommittedNode) => {
           return (

--- a/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
@@ -171,6 +171,22 @@ describe("The ProjectContactFormSummary", () => {
     componentTestingHelper.reinit();
   });
 
+  it("Displays primary contact and secondary contacts on view mode", () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent(undefined, {
+      viewOnly: true,
+    });
+
+    // Primary contact
+    expect(screen.getByText(/primary contact/i)).toBeInTheDocument();
+    expect(screen.getByText(/Test Full Name primary/i)).toBeInTheDocument();
+
+    // Secondary contacts
+    expect(screen.getByText(/secondary contacts/i)).toBeInTheDocument();
+    expect(screen.getByText(/I did not change/i)).toBeInTheDocument();
+    expect(screen.getByText(/I was added/i)).toBeInTheDocument();
+  });
+
   it("Only displays the data fields that have changed", () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();


### PR DESCRIPTION
[ZH CARD 1808](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-cif/1808)