### PR TITLE
fix: 1788 show budgets diffs triggered by milestone changes

### DIFF
--- a/app/components/Form/ProjectFundingAgreementFormSummary.tsx
+++ b/app/components/Form/ProjectFundingAgreementFormSummary.tsx
@@ -70,7 +70,6 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
                   }
                 }
               }
-              isPristine
               operation
               formChangeByPreviousFormChangeId {
                 newFormData
@@ -219,6 +218,12 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
   // Show diff if it is not the first revision and not view only (rendered from the overview page)
   const renderDiff = !isFirstRevision && !viewOnly;
 
+  const filteredSchema = getSchemaAndDataIncludingCalculatedValues(
+    schema as JSONSchema7,
+    newData,
+    oldData
+  );
+
   // Set the formSchema and formData based on showing the diff or not
   const { formSchema, formData } = !renderDiff
     ? {
@@ -230,21 +235,11 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
           ),
         },
       }
-    : {
-        ...getSchemaAndDataIncludingCalculatedValues(
-          schema as JSONSchema7,
-          newData,
-          oldData
-        ),
-      };
+    : filteredSchema;
 
   const fundingAgreementFormNotUpdated = useMemo(
-    () =>
-      !fundingAgreementSummary ||
-      fundingAgreementSummary?.isPristine ||
-      (fundingAgreementSummary?.isPristine === null &&
-        Object.keys(fundingAgreementSummary?.newFormData).length === 0),
-    [fundingAgreementSummary]
+    () => Object.keys(filteredSchema.formData).length === 0,
+    [filteredSchema.formData]
   );
 
   const createUiSchema = useMemo(() => {

--- a/app/lib/theme/schemaFilteringHelpers.ts
+++ b/app/lib/theme/schemaFilteringHelpers.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema7 } from "json-schema";
+import { isEqual } from "lodash";
 
 // The two functions below filter out fields from the formSchema that have not changed from the previous revision so the summary ignores these fields
 // This is mainly used when the form has multiple fields within it and we want to check each field data with the previous revision
@@ -22,14 +23,17 @@ export const getSchemaAndDataIncludingCalculatedValues = (
 
   for (const key of Object.keys(filteredSchema.properties)) {
     // null new data with undefined old data occurs when an optional form (e.g. budgets) is created but not filled
+
     if (
       formDataIncludingCalculatedValues?.[key] === null &&
       oldFormDataIncludingCalculatedValues?.[key] === undefined
     ) {
       delete filteredSchema.properties[key];
     } else if (
-      formDataIncludingCalculatedValues?.[key] ===
-      oldFormDataIncludingCalculatedValues?.[key]
+      isEqual(
+        formDataIncludingCalculatedValues?.[key],
+        oldFormDataIncludingCalculatedValues?.[key]
+      )
     ) {
       delete filteredSchema.properties[key];
     } else newDataObject[key] = formDataIncludingCalculatedValues?.[key];

--- a/app/package.json
+++ b/app/package.json
@@ -111,6 +111,7 @@
     "html-react-parser": "^3.0.16",
     "json-schema": "^0.4.0",
     "lightship": "^7.1.1",
+    "lodash": "^4.17.21",
     "luxon": "^3.2.1",
     "morgan": "^1.10.0",
     "next": "^13.1.6",

--- a/app/pages/cif/project-revision/[projectRevision]/edit.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/edit.tsx
@@ -63,6 +63,8 @@ export const EditProjectRevisionQuery = graphql`
     }
     # eslint-disable-next-line relay/must-colocate-fragment-spreads
     ...ProjectFundingAgreementFormSummary_query
+    # eslint-disable-next-line relay/must-colocate-fragment-spreads
+    ...ProjectEmissionIntensityReportFormSummary_query
   }
 `;
 

--- a/app/pages/cif/project-revision/[projectRevision]/form/[formIndex]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/[formIndex]/index.tsx
@@ -16,6 +16,7 @@ const pageQuery = graphql`
         ...DefaultLayout_session
       }
       ...ProjectFundingAgreementFormSummary_query
+      ...ProjectEmissionIntensityReportFormSummary_query
       projectRevision(id: $projectRevision) {
         id
         changeStatus
@@ -66,7 +67,6 @@ const pageQuery = graphql`
       ...ProjectFundingAgreementForm_query
       ...ProjectFundingAgreementFormSummary_query
       ...ProjectEmissionIntensityReportForm_query
-      ...ProjectEmissionIntensityReportFormSummary_query
       ...ProjectEmissionIntensityReportFormSummary_query
     }
   }

--- a/app/pages/cif/project-revision/[projectRevision]/form/[formIndex]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/form/[formIndex]/index.tsx
@@ -66,6 +66,8 @@ const pageQuery = graphql`
       ...ProjectFundingAgreementForm_query
       ...ProjectFundingAgreementFormSummary_query
       ...ProjectEmissionIntensityReportForm_query
+      ...ProjectEmissionIntensityReportFormSummary_query
+      ...ProjectEmissionIntensityReportFormSummary_query
     }
   }
 `;

--- a/app/pages/cif/project-revision/[projectRevision]/index.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/index.tsx
@@ -81,6 +81,7 @@ const pageQuery = graphql`
         }
       }
       ...ProjectFundingAgreementFormSummary_query
+      ...ProjectEmissionIntensityReportFormSummary_query
     }
   }
 `;
@@ -242,6 +243,7 @@ export function ProjectRevision({
             />
             <ProjectEmissionsIntensityReportFormSummary
               projectRevision={query.projectRevision}
+              query={query}
             />
             <ProjectAnnualReportFormSummary
               projectRevision={query.projectRevision}

--- a/app/pages/cif/project-revision/[projectRevision]/view.tsx
+++ b/app/pages/cif/project-revision/[projectRevision]/view.tsx
@@ -60,6 +60,8 @@ export const ViewProjectRevisionQuery = graphql`
     }
     # eslint-disable-next-line relay/must-colocate-fragment-spreads
     ...ProjectFundingAgreementFormSummary_query
+    # eslint-disable-next-line relay/must-colocate-fragment-spreads
+    ...ProjectEmissionIntensityReportFormSummary_query
   }
 `;
 

--- a/app/tests/unit/components/Form/ProjectEmissionIntensityReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectEmissionIntensityReportFormSummary.test.tsx
@@ -14,6 +14,7 @@ const testQuery = graphql`
       projectRevision(id: "Test Project Revision ID") {
         ...ProjectEmissionIntensityReportFormSummary_projectRevision
       }
+      ...ProjectEmissionIntensityReportFormSummary_query
     }
   }
 `;
@@ -325,7 +326,7 @@ describe("the emission intensity report form component", () => {
       ProjectRevision() {
         return {
           isFirstRevision: true,
-          summaryEmissionIntensityReportFormChange: {
+          summaryEmissionIntensityReportingRequirementFormChange: {
             edges: [
               {
                 node: {


### PR DESCRIPTION
card: https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-cif/1788

Note: Anticipated Funding Per Fiscal Year is no longer in the happo shot. That's correct--the cypress test doesn't change anything that would create a diff in anticipated funding.