### PR TITLE
fix: remove hanging quote

### DIFF
--- a/chart/cas-cif/templates/terraform/terraform-apply.yaml
+++ b/chart/cas-cif/templates/terraform/terraform-apply.yaml
@@ -55,7 +55,7 @@ spec:
                   cd working;
                   export TF_VAR_kubernetes_token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token );
                   terraform init -backend-config=/etc/tf/gcs.tfbackend;
-                  terraform apply -var=\"kubernetes_host=$kubernetes_host\" -auto-approve";
+                  terraform apply -var="kubernetes_host=$kubernetes_host" -auto-approve;
       restartPolicy: Never
       volumes:
         - name: service-account-credentials-volume


### PR DESCRIPTION
When deploying #1887, Terraform initializes in the job's pod, but fails on line 58 due to `/bin/sh: syntax error: unterminated quoted string`, a hanging `"`. This fix removes the erroneous quote mark.