### PR TITLE
chore: update zaproxy action version and image source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,10 +194,10 @@ jobs:
       - name: run app locally
         uses: ./.github/actions/local-app-run
       - name: ZAP Base Scan
-        uses: zaproxy/action-baseline@v0.6.1
+        uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: "owasp/zap2docker-stable"
+          docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           target: "http://localhost:3004/"
           rules_file_name: ".zap/rules.tsv"
           cmd_options: "-a -d -T 5 -m 2"


### PR DESCRIPTION
The image being used for Zaproxy can't be found anymore so we've changed the image source and bumped the action version.