### PR TITLE
Feat/clearer diffs

### DIFF
--- a/app/components/Attachment/AttachmentTableRow.tsx
+++ b/app/components/Attachment/AttachmentTableRow.tsx
@@ -68,7 +68,10 @@ const AttachmentTableRow: React.FC<Props> = ({
     <>
       <tr>
         {operation && (
-          <td>{operation.charAt(0).toUpperCase() + operation.slice(1).toLowerCase()}</td>
+          <td>
+            {operation.charAt(0).toUpperCase() +
+              operation.slice(1).toLowerCase()}
+          </td>
         )}
         <td>{fileName}</td>
         <td>{fileType}</td>

--- a/app/components/Attachment/AttachmentTableRow.tsx
+++ b/app/components/Attachment/AttachmentTableRow.tsx
@@ -13,6 +13,7 @@ interface Props {
   formChangeRowId: number;
   hideDelete?: boolean;
   isFirstRevision: boolean;
+  operation?: string;
 }
 
 const AttachmentTableRow: React.FC<Props> = ({
@@ -21,6 +22,7 @@ const AttachmentTableRow: React.FC<Props> = ({
   formChangeRowId,
   hideDelete,
   isFirstRevision,
+  operation,
 }) => {
   const [
     discardProjectAttachmentFormChange,
@@ -65,6 +67,9 @@ const AttachmentTableRow: React.FC<Props> = ({
   return (
     <>
       <tr>
+        {operation && (
+          <td>{operation.charAt(0).toUpperCase() + operation.slice(1).toLowerCase()}</td>
+        )}
         <td>{fileName}</td>
         <td>{fileType}</td>
         <td>{fileSize}</td>

--- a/app/components/Form/Functions/getMilestoneFilteredSchema.ts
+++ b/app/components/Form/Functions/getMilestoneFilteredSchema.ts
@@ -12,7 +12,8 @@ import { JSONSchema7 } from "json-schema";
  */
 export const getMilestoneFilteredSchema = (
   formSchema: JSONSchema7,
-  formChange
+  formChange,
+  latestCommittedFormChange
 ) => {
   const properties = formSchema.properties;
   // schema dependencies
@@ -37,7 +38,7 @@ export const getMilestoneFilteredSchema = (
   for (const key of Object.keys(filteredSchema.properties)) {
     const [updatedFormData, prevFormData] = [
       formChange?.newFormData?.[key],
-      formChange?.formChangeByPreviousFormChangeId?.newFormData?.[key],
+      latestCommittedFormChange?.newFormData?.[key],
     ];
     if (
       updatedFormData === prevFormData ||

--- a/app/components/Form/ProjectAnnualReportFormSummary.tsx
+++ b/app/components/Form/ProjectAnnualReportFormSummary.tsx
@@ -46,9 +46,6 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
               isPristine
               newFormData
               operation
-              formChangeByPreviousFormChangeId {
-                newFormData
-              }
               formByJsonSchemaName {
                 jsonSchema
               }
@@ -162,8 +159,6 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
               uiSchema={reportingRequirementUiSchema}
               formContext={{
                 operation: annualReport.operation,
-                oldData:
-                  annualReport.formChangeByPreviousFormChangeId?.newFormData,
                 latestCommittedData,
                 isAmendmentsAndOtherRevisionsSpecific:
                   isOnAmendmentsAndOtherRevisionsPage,

--- a/app/components/Form/ProjectAnnualReportFormSummary.tsx
+++ b/app/components/Form/ProjectAnnualReportFormSummary.tsx
@@ -90,6 +90,15 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
     return [filteredReports];
   }, [annualReportFormChanges]);
 
+  let latestCommittedReports = latestCommittedAnnualReportFormChanges.edges;
+  const latestCommittedReportMap = useMemo(() => {
+    const filteredReports = latestCommittedReports.map(({ node }) => node);
+
+    const reportMap = filteredReports.reduce((reports, current) => (reports[current.newFormData.reportingRequirementIndex] = current, reports),{})
+
+    return reportMap;
+  }, [latestCommittedReports]);
+
   const allFormChangesPristine = useMemo(
     () =>
       !annualReportFormChanges.some(
@@ -109,7 +118,8 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
           }
         : getFilteredSchema(
             annualReport.formByJsonSchemaName.jsonSchema.schema as JSONSchema7,
-            annualReport
+            annualReport,
+            latestCommittedReportMap[annualReport.newFormData.reportingRequirementIndex]
           );
 
       if (

--- a/app/components/Form/ProjectAnnualReportFormSummary.tsx
+++ b/app/components/Form/ProjectAnnualReportFormSummary.tsx
@@ -94,7 +94,13 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
   const latestCommittedReportMap = useMemo(() => {
     const filteredReports = latestCommittedReports.map(({ node }) => node);
 
-    const reportMap = filteredReports.reduce((reports, current) => (reports[current.newFormData.reportingRequirementIndex] = current, reports),{})
+    const reportMap = filteredReports.reduce(
+      (reports, current) => (
+        (reports[current.newFormData.reportingRequirementIndex] = current),
+        reports
+      ),
+      {}
+    );
 
     return reportMap;
   }, [latestCommittedReports]);
@@ -119,7 +125,9 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
         : getFilteredSchema(
             annualReport.formByJsonSchemaName.jsonSchema.schema as JSONSchema7,
             annualReport,
-            latestCommittedReportMap[annualReport.newFormData.reportingRequirementIndex]
+            latestCommittedReportMap[
+              annualReport.newFormData.reportingRequirementIndex
+            ]
           );
 
       if (

--- a/app/components/Form/ProjectAnnualReportFormSummary.tsx
+++ b/app/components/Form/ProjectAnnualReportFormSummary.tsx
@@ -115,7 +115,10 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
 
   const annualReportsJSX = useMemo(() => {
     return sortedAnnualReports.map((annualReport, index) => {
-      const latestCommittedData = latestCommittedReportMap[annualReport.newFormData.reportingRequirementIndex]
+      const latestCommittedData =
+        latestCommittedReportMap[
+          annualReport.newFormData.reportingRequirementIndex
+        ];
       if (!annualReport) return;
       // Set the formSchema and formData based on showing the diff or not
       const { formSchema, formData } = !renderDiff
@@ -188,7 +191,7 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
     isOnAmendmentsAndOtherRevisionsPage,
     renderDiff,
     sortedAnnualReports,
-    latestCommittedReportMap
+    latestCommittedReportMap,
   ]);
 
   // Update the hasDiff state in the CollapsibleFormWidget to define if the form has diffs to show

--- a/app/components/Form/ProjectAnnualReportFormSummary.tsx
+++ b/app/components/Form/ProjectAnnualReportFormSummary.tsx
@@ -115,6 +115,7 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
 
   const annualReportsJSX = useMemo(() => {
     return sortedAnnualReports.map((annualReport, index) => {
+      const latestCommittedData = latestCommittedReportMap[annualReport.newFormData.reportingRequirementIndex]
       if (!annualReport) return;
       // Set the formSchema and formData based on showing the diff or not
       const { formSchema, formData } = !renderDiff
@@ -125,9 +126,7 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
         : getFilteredSchema(
             annualReport.formByJsonSchemaName.jsonSchema.schema as JSONSchema7,
             annualReport,
-            latestCommittedReportMap[
-              annualReport.newFormData.reportingRequirementIndex
-            ]
+            latestCommittedData
           );
 
       if (
@@ -136,13 +135,6 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
         annualReport.operation !== "ARCHIVE"
       )
         return null;
-
-      const latestCommittedData =
-        latestCommittedAnnualReportFormChanges?.edges?.find(
-          ({ node }) =>
-            node.newFormData.reportingRequirementIndex ===
-            annualReport.newFormData.reportingRequirementIndex
-        )?.node?.newFormData;
 
       return (
         <div key={index} className="reportContainer">
@@ -177,7 +169,7 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
               uiSchema={reportingRequirementUiSchema}
               formContext={{
                 operation: annualReport.operation,
-                latestCommittedData,
+                latestCommittedData: latestCommittedData?.newFormData,
                 isAmendmentsAndOtherRevisionsSpecific:
                   isOnAmendmentsAndOtherRevisionsPage,
               }}
@@ -196,6 +188,7 @@ const ProjectAnnualReportFormSummary: React.FC<Props> = ({
     isOnAmendmentsAndOtherRevisionsPage,
     renderDiff,
     sortedAnnualReports,
+    latestCommittedReportMap
   ]);
 
   // Update the hasDiff state in the CollapsibleFormWidget to define if the form has diffs to show

--- a/app/components/Form/ProjectAttachmentsFormSummary.tsx
+++ b/app/components/Form/ProjectAttachmentsFormSummary.tsx
@@ -7,6 +7,7 @@ import { FormNotAddedOrUpdated } from "./SummaryFormCommonComponents";
 import { useEffect, useMemo } from "react";
 
 const tableFilters = [
+  new TextFilter("Operation", "operation"),
   new TextFilter("File Name", "fileName"),
   new TextFilter("Type", "type"),
   new TextFilter("Size", "size"),
@@ -36,7 +37,6 @@ const ProjectAttachmentsFormSummary: React.FC<Props> = ({
         summaryProjectAttachmentFormChanges: formChangesFor(
           first: 500
           formDataTableName: "project_attachment"
-          filter: { operation: { notEqualTo: ARCHIVE } }
         ) @connection(key: "connection_summaryProjectAttachmentFormChanges") {
           __id
           totalCount
@@ -115,6 +115,7 @@ const ProjectAttachmentsFormSummary: React.FC<Props> = ({
             ({ node }) => (
               <AttachmentTableRow
                 key={node.id}
+                operation={node.operation}
                 attachment={node.asProjectAttachment.attachmentByAttachmentId}
                 formChangeRowId={node.rowId}
                 connectionId={revision.summaryProjectAttachmentFormChanges.__id}

--- a/app/components/Form/ProjectContactFormSummary.tsx
+++ b/app/components/Form/ProjectContactFormSummary.tsx
@@ -192,7 +192,7 @@ const ProjectContactFormSummary: React.FC<Props> = ({
     secondaryContacts,
     renderDiff,
     isOnAmendmentsAndOtherRevisionsPage,
-    summaryContactFormChanges,
+    lastCommittedSecondaryContacts,
   ]);
 
   // Update the hasDiff state in the CollapsibleFormWidget to define if the form has diffs to show

--- a/app/components/Form/ProjectContactFormSummary.tsx
+++ b/app/components/Form/ProjectContactFormSummary.tsx
@@ -181,11 +181,6 @@ const ProjectContactFormSummary: React.FC<Props> = ({
             formData={node.newFormData}
             formContext={{
               operation: node.operation,
-              oldData: node.formChangeByPreviousFormChangeId?.newFormData,
-              oldUiSchema: createProjectContactUiSchema(
-                node?.formChangeByPreviousFormChangeId?.asProjectContact
-                  ?.contactByContactId?.fullName
-              ),
               latestCommittedData:
                 latestCommittedContactNode?.node?.newFormData,
               latestCommittedUiSchema,
@@ -260,13 +255,6 @@ const ProjectContactFormSummary: React.FC<Props> = ({
               formData={primaryContact ? primaryContact.node.newFormData : null}
               formContext={{
                 operation: primaryContact?.node.operation,
-                oldData:
-                  primaryContact?.node.formChangeByPreviousFormChangeId
-                    ?.newFormData,
-                oldUiSchema: createProjectContactUiSchema(
-                  primaryContact?.node?.formChangeByPreviousFormChangeId
-                    ?.asProjectContact?.contactByContactId?.fullName
-                ),
                 latestCommittedData:
                   lastCommittedPrimaryContact?.node?.newFormData,
                 latestCommittedUiSchema: createProjectContactUiSchema(

--- a/app/components/Form/ProjectContactFormSummary.tsx
+++ b/app/components/Form/ProjectContactFormSummary.tsx
@@ -48,14 +48,6 @@ const ProjectContactFormSummary: React.FC<Props> = ({
                   ...ContactDetails_contact
                 }
               }
-              formChangeByPreviousFormChangeId {
-                newFormData
-                asProjectContact {
-                  contactByContactId {
-                    fullName
-                  }
-                }
-              }
               formByJsonSchemaName {
                 jsonSchema
               }

--- a/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
@@ -51,13 +51,6 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
               formByJsonSchemaName {
                 jsonSchema
               }
-              formChangeByPreviousFormChangeId {
-                newFormData
-                calculatedEiPerformance
-                paymentPercentage
-                maximumPerformanceMilestoneAmount
-                actualPerformanceMilestoneAmount
-              }
             }
           }
         }
@@ -97,24 +90,6 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
       summaryReportingRequirement?.actualPerformanceMilestoneAmount,
   };
 
-  const oldData = {
-    ...summaryReportingRequirement?.formChangeByPreviousFormChangeId
-      ?.newFormData,
-    //calculated values
-    calculatedEiPerformance:
-      summaryReportingRequirement?.formChangeByPreviousFormChangeId
-        ?.calculatedEiPerformance,
-    paymentPercentage:
-      summaryReportingRequirement?.formChangeByPreviousFormChangeId
-        ?.paymentPercentage,
-    maximumPerformanceMilestoneAmount:
-      summaryReportingRequirement?.formChangeByPreviousFormChangeId
-        ?.maximumPerformanceMilestoneAmount,
-    actualPerformanceMilestoneAmount:
-      summaryReportingRequirement?.formChangeByPreviousFormChangeId
-        ?.actualPerformanceMilestoneAmount,
-  };
-
   const latestCommittedData = {
     ...latestCommittedEmissionIntensityReportFormChange?.edges[0]?.node
       ?.newFormData,
@@ -147,7 +122,6 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
   const filteredSchema = getSchemaAndDataIncludingCalculatedValues(
     emissionIntensityFormBySlug.jsonSchema.schema as JSONSchema7,
     newData,
-    oldData,
     {
       // This is only to add the (Adjusted) to the title of the field to differentiate it from the calculated field
       adjustedEmissionsIntensityPerformance: {
@@ -265,7 +239,6 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
           actualPerformanceMilestoneAmount:
             summaryReportingRequirement?.actualPerformanceMilestoneAmount,
           operation: summaryReportingRequirement?.operation,
-          oldData,
           latestCommittedData,
           isAmendmentsAndOtherRevisionsSpecific:
             isOnAmendmentsAndOtherRevisionsPage,

--- a/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
@@ -122,6 +122,7 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
   const filteredSchema = getSchemaAndDataIncludingCalculatedValues(
     emissionIntensityFormBySlug.jsonSchema.schema as JSONSchema7,
     newData,
+    latestCommittedData,
     {
       // This is only to add the (Adjusted) to the title of the field to differentiate it from the calculated field
       adjustedEmissionsIntensityPerformance: {

--- a/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
+++ b/app/components/Form/ProjectEmissionIntensityReportFormSummary.tsx
@@ -55,7 +55,8 @@ const ProjectEmissionsIntensityReportFormSummary: React.FC<Props> = ({
           }
         }
         latestCommittedEmissionIntensityReportFormChange: latestCommittedFormChangesFor(
-          formDataTableName: "emission_intensity_report"
+          formDataTableName: "reporting_requirement"
+          reportType: "TEIMP"
         ) {
           edges {
             node {

--- a/app/components/Form/ProjectFormSummary.tsx
+++ b/app/components/Form/ProjectFormSummary.tsx
@@ -93,12 +93,13 @@ const ProjectFormSummary: React.FC<Props> = ({
 
   const newDataAsProject = projectFormChange.asProject;
 
-  const latestCommittedUiSchema = latestCommittedData?.asProject
+  const latestCommittedAsProject = latestCommittedProjectFormChanges?.edges[0]?.node?.asProject
+  const latestCommittedUiSchema = latestCommittedAsProject
     ? createProjectUiSchema(
-        latestCommittedData.asProject.operatorByOperatorId.legalName,
-        `${latestCommittedData.asProject?.fundingStreamRfpByFundingStreamRfpId?.fundingStreamByFundingStreamId.description} - ${latestCommittedData.asProject?.fundingStreamRfpByFundingStreamRfpId?.year}`,
-        latestCommittedData.asProject.operatorByOperatorId.bcRegistryId,
-        latestCommittedData.asProject.projectStatusByProjectStatusId.name
+        latestCommittedAsProject.operatorByOperatorId.legalName,
+        `${latestCommittedAsProject?.fundingStreamRfpByFundingStreamRfpId?.fundingStreamByFundingStreamId.description} - ${latestCommittedAsProject?.fundingStreamRfpByFundingStreamRfpId?.year}`,
+        latestCommittedAsProject.operatorByOperatorId.bcRegistryId,
+        latestCommittedAsProject.projectStatusByProjectStatusId.name
       )
     : null;
 
@@ -113,6 +114,7 @@ const ProjectFormSummary: React.FC<Props> = ({
           projectSchema as JSONSchema7,
 
           { ...projectFormChange?.newFormData, rank: projectFormChange.rank },
+          latestCommittedData,
           {
             rank: {
               type: "number",

--- a/app/components/Form/ProjectFormSummary.tsx
+++ b/app/components/Form/ProjectFormSummary.tsx
@@ -93,7 +93,8 @@ const ProjectFormSummary: React.FC<Props> = ({
 
   const newDataAsProject = projectFormChange.asProject;
 
-  const latestCommittedAsProject = latestCommittedProjectFormChanges?.edges[0]?.node?.asProject
+  const latestCommittedAsProject =
+    latestCommittedProjectFormChanges?.edges[0]?.node?.asProject;
   const latestCommittedUiSchema = latestCommittedAsProject
     ? createProjectUiSchema(
         latestCommittedAsProject.operatorByOperatorId.legalName,

--- a/app/components/Form/ProjectFormSummary.tsx
+++ b/app/components/Form/ProjectFormSummary.tsx
@@ -52,25 +52,6 @@ const ProjectFormSummary: React.FC<Props> = ({
               name
             }
           }
-          formChangeByPreviousFormChangeId {
-            rank
-            newFormData
-            asProject {
-              operatorByOperatorId {
-                legalName
-                bcRegistryId
-              }
-              fundingStreamRfpByFundingStreamRfpId {
-                year
-                fundingStreamByFundingStreamId {
-                  description
-                }
-              }
-              projectStatusByProjectStatusId {
-                name
-              }
-            }
-          }
         }
         latestCommittedProjectFormChanges: latestCommittedFormChangesFor(
           formDataTableName: "project"
@@ -110,23 +91,7 @@ const ProjectFormSummary: React.FC<Props> = ({
   // Show diff if it is not the first revision and not view only (rendered from the overview page)
   const renderDiff = !isFirstRevision && !viewOnly;
 
-  const oldData = {
-    ...projectFormChange.formChangeByPreviousFormChangeId?.newFormData,
-    rank: projectFormChange.formChangeByPreviousFormChangeId?.rank,
-  };
-
   const newDataAsProject = projectFormChange.asProject;
-  const previousDataAsProject =
-    projectFormChange.formChangeByPreviousFormChangeId?.asProject;
-
-  const oldUiSchema = previousDataAsProject
-    ? createProjectUiSchema(
-        previousDataAsProject.operatorByOperatorId.legalName,
-        `${previousDataAsProject?.fundingStreamRfpByFundingStreamRfpId?.fundingStreamByFundingStreamId.description} - ${previousDataAsProject?.fundingStreamRfpByFundingStreamRfpId?.year}`,
-        previousDataAsProject.operatorByOperatorId.bcRegistryId,
-        previousDataAsProject.projectStatusByProjectStatusId.name
-      )
-    : null;
 
   const latestCommittedUiSchema = latestCommittedData?.asProject
     ? createProjectUiSchema(
@@ -148,7 +113,6 @@ const ProjectFormSummary: React.FC<Props> = ({
           projectSchema as JSONSchema7,
 
           { ...projectFormChange?.newFormData, rank: projectFormChange.rank },
-          oldData,
           {
             rank: {
               type: "number",
@@ -199,8 +163,6 @@ const ProjectFormSummary: React.FC<Props> = ({
           formData={formData}
           formContext={{
             calculatedRank: projectFormChange.rank,
-            oldData,
-            oldUiSchema,
             latestCommittedData,
             latestCommittedUiSchema,
             operation: projectFormChange.operation,

--- a/app/components/Form/ProjectFundingAgreementFormSummary.tsx
+++ b/app/components/Form/ProjectFundingAgreementFormSummary.tsx
@@ -71,25 +71,6 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
                 }
               }
               operation
-              formChangeByPreviousFormChangeId {
-                newFormData
-                eligibleExpensesToDate
-                holdbackAmountToDate
-                netPaymentsToDate
-                grossPaymentsToDate
-                calculatedTotalPaymentAmountToDate
-                proponentsSharePercentage
-                totalProjectValue
-                anticipatedFundingAmountPerFiscalYear {
-                  edges {
-                    # eslint-disable-next-line relay/unused-fields
-                    node {
-                      anticipatedFundingAmount
-                      fiscalYear
-                    }
-                  }
-                }
-              }
             }
           }
         }
@@ -169,25 +150,6 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
     ),
   };
 
-  const oldFundingFormChanges =
-    revision.summaryProjectFundingAgreementFormChanges.edges[0]?.node
-      .formChangeByPreviousFormChangeId;
-
-  const oldData = {
-    ...oldFundingFormChanges?.newFormData,
-    eligibleExpensesToDate: oldFundingFormChanges?.eligibleExpensesToDate,
-    holdbackAmountToDate: oldFundingFormChanges?.holdbackAmountToDate,
-    netPaymentsToDate: oldFundingFormChanges?.netPaymentsToDate,
-    grossPaymentsToDate: oldFundingFormChanges?.grossPaymentsToDate,
-    totalPaymentAmountToDate:
-      oldFundingFormChanges?.calculatedTotalPaymentAmountToDate,
-    proponentsSharePercentage: oldFundingFormChanges?.proponentsSharePercentage,
-    totalProjectValue: oldFundingFormChanges?.totalProjectValue,
-    anticipatedFundingAmountPerFiscalYear: cleanupNestedNodes(
-      oldFundingFormChanges?.anticipatedFundingAmountPerFiscalYear.edges
-    ),
-  };
-
   const fundingStream =
     revision.projectFormChange.asProject.fundingStreamRfpByFundingStreamRfpId
       .fundingStreamByFundingStreamId.name;
@@ -223,7 +185,7 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
   const filteredSchema = getSchemaAndDataIncludingCalculatedValues(
     schema as JSONSchema7,
     newData,
-    oldData
+    latestCommittedData
   );
 
   // Set the formSchema and formData based on showing the diff or not
@@ -342,7 +304,6 @@ const ProjectFundingAgreementFormSummary: React.FC<Props> = ({
               fundingAgreementSummary?.totalProjectValue,
             calculatedProponentsSharePercentage:
               fundingAgreementSummary?.proponentsSharePercentage,
-            oldData,
             latestCommittedData,
             isAmendmentsAndOtherRevisionsSpecific:
               isOnAmendmentsAndOtherRevisionsPage,

--- a/app/components/Form/ProjectManagerFormSummary.tsx
+++ b/app/components/Form/ProjectManagerFormSummary.tsx
@@ -42,14 +42,6 @@ const ProjectManagerFormSummary: React.FC<Props> = ({
                     fullName
                   }
                 }
-                formChangeByPreviousFormChangeId {
-                  newFormData
-                  asProjectManager {
-                    cifUserByCifUserId {
-                      fullName
-                    }
-                  }
-                }
                 formByJsonSchemaName {
                   jsonSchema
                 }
@@ -146,12 +138,6 @@ const ProjectManagerFormSummary: React.FC<Props> = ({
           formData={node.formChange.newFormData}
           formContext={{
             operation: node.formChange?.operation,
-            oldData:
-              node.formChange?.formChangeByPreviousFormChangeId?.newFormData,
-            oldUiSchema: createProjectManagerUiSchema(
-              node.formChange?.formChangeByPreviousFormChangeId
-                ?.asProjectManager?.cifUserByCifUserId?.fullName
-            ),
             latestCommittedData: latestCommittedManagerNode?.node?.newFormData,
             latestCommittedUiSchema,
             isAmendmentsAndOtherRevisionsSpecific:

--- a/app/components/Form/ProjectMilestoneReportFormSummary.tsx
+++ b/app/components/Form/ProjectMilestoneReportFormSummary.tsx
@@ -50,9 +50,6 @@ const ProjectMilestoneReportFormSummary: React.FC<Props> = ({
               isPristine
               newFormData
               operation
-              formChangeByPreviousFormChangeId {
-                newFormData
-              }
               formByJsonSchemaName {
                 jsonSchema
               }
@@ -243,8 +240,6 @@ const ProjectMilestoneReportFormSummary: React.FC<Props> = ({
               calculatedNetAmount:
                 milestoneReport?.newFormData?.calculatedNetAmount,
               operation: milestoneReport.operation,
-              oldData:
-                milestoneReport.formChangeByPreviousFormChangeId?.newFormData,
               latestCommittedData,
               isAmendmentsAndOtherRevisionsSpecific:
                 isOnAmendmentsAndOtherRevisionsPage,

--- a/app/components/Form/ProjectMilestoneReportFormSummary.tsx
+++ b/app/components/Form/ProjectMilestoneReportFormSummary.tsx
@@ -281,7 +281,7 @@ const ProjectMilestoneReportFormSummary: React.FC<Props> = ({
     latestCommittedMilestoneFormChanges?.edges,
     renderDiff,
     sortedMilestoneReports,
-    latestCommittedReportMap
+    latestCommittedReportMap,
   ]);
 
   const milestoneReportsNotUpdated = useMemo(

--- a/app/components/Form/ProjectMilestoneReportFormSummary.tsx
+++ b/app/components/Form/ProjectMilestoneReportFormSummary.tsx
@@ -83,6 +83,21 @@ const ProjectMilestoneReportFormSummary: React.FC<Props> = ({
         ({ node }) => node.operation !== "ARCHIVE"
       );
 
+  let latestCommittedReports = latestCommittedMilestoneFormChanges.edges;
+  const latestCommittedReportMap = useMemo(() => {
+    const filteredReports = latestCommittedReports.map(({ node }) => node);
+
+    const reportMap = filteredReports.reduce(
+      (reports, current) => (
+        (reports[current.newFormData.reportingRequirementIndex] = current),
+        reports
+      ),
+      {}
+    );
+
+    return reportMap;
+  }, [latestCommittedReports]);
+
   // Sort consolidated milestone form change records
   const [sortedMilestoneReports] = useMemo(() => {
     return getSortedReports(milestoneReportFormChanges, true);
@@ -139,7 +154,10 @@ const ProjectMilestoneReportFormSummary: React.FC<Props> = ({
             },
             {
               ...milestoneReport,
-            }
+            },
+            latestCommittedReportMap[
+              milestoneReport.newFormData.reportingRequirementIndex
+            ]
           )
         : {
             formSchema: milestoneReport.formByJsonSchemaName.jsonSchema.schema,

--- a/app/components/Form/ProjectMilestoneReportFormSummary.tsx
+++ b/app/components/Form/ProjectMilestoneReportFormSummary.tsx
@@ -281,6 +281,7 @@ const ProjectMilestoneReportFormSummary: React.FC<Props> = ({
     latestCommittedMilestoneFormChanges?.edges,
     renderDiff,
     sortedMilestoneReports,
+    latestCommittedReportMap
   ]);
 
   const milestoneReportsNotUpdated = useMemo(

--- a/app/components/Form/ProjectQuarterlyReportFormSummary.tsx
+++ b/app/components/Form/ProjectQuarterlyReportFormSummary.tsx
@@ -47,9 +47,6 @@ const ProjectQuarterlyReportFormSummary: React.FC<Props> = ({
               isPristine
               newFormData
               operation
-              formChangeByPreviousFormChangeId {
-                newFormData
-              }
               formByJsonSchemaName {
                 jsonSchema
               }
@@ -169,8 +166,6 @@ const ProjectQuarterlyReportFormSummary: React.FC<Props> = ({
               formData={formData}
               formContext={{
                 operation: quarterlyReport.operation,
-                oldData:
-                  quarterlyReport.formChangeByPreviousFormChangeId?.newFormData,
                 latestCommittedData,
                 isAmendmentsAndOtherRevisionsSpecific:
                   isOnAmendmentsAndOtherRevisionsPage,

--- a/app/components/Form/ProjectQuarterlyReportFormSummary.tsx
+++ b/app/components/Form/ProjectQuarterlyReportFormSummary.tsx
@@ -94,7 +94,8 @@ const ProjectQuarterlyReportFormSummary: React.FC<Props> = ({
     return [filteredReports];
   }, [quarterlyReportFormChanges]);
 
-  let latestCommittedReports = latestCommittedProjectQuarterlyReportFormChanges.edges;
+  let latestCommittedReports =
+    latestCommittedProjectQuarterlyReportFormChanges.edges;
   const latestCommittedReportMap = useMemo(() => {
     const filteredReports = latestCommittedReports.map(({ node }) => node);
 
@@ -132,7 +133,9 @@ const ProjectQuarterlyReportFormSummary: React.FC<Props> = ({
             quarterlyReport.formByJsonSchemaName.jsonSchema
               .schema as JSONSchema7,
             quarterlyReport,
-            latestCommittedReportMap[quarterlyReport.newFormData.reportingRequirementIndex]
+            latestCommittedReportMap[
+              quarterlyReport.newFormData.reportingRequirementIndex
+            ]
           );
 
       if (

--- a/app/components/Form/ProjectQuarterlyReportFormSummary.tsx
+++ b/app/components/Form/ProjectQuarterlyReportFormSummary.tsx
@@ -94,6 +94,21 @@ const ProjectQuarterlyReportFormSummary: React.FC<Props> = ({
     return [filteredReports];
   }, [quarterlyReportFormChanges]);
 
+  let latestCommittedReports = latestCommittedProjectQuarterlyReportFormChanges.edges;
+  const latestCommittedReportMap = useMemo(() => {
+    const filteredReports = latestCommittedReports.map(({ node }) => node);
+
+    const reportMap = filteredReports.reduce(
+      (reports, current) => (
+        (reports[current.newFormData.reportingRequirementIndex] = current),
+        reports
+      ),
+      {}
+    );
+
+    return reportMap;
+  }, [latestCommittedReports]);
+
   // Defines if all quarterly reports are pristine
   const allFormChangesPristine = useMemo(
     () =>
@@ -116,7 +131,8 @@ const ProjectQuarterlyReportFormSummary: React.FC<Props> = ({
         : getFilteredSchema(
             quarterlyReport.formByJsonSchemaName.jsonSchema
               .schema as JSONSchema7,
-            quarterlyReport
+            quarterlyReport,
+            latestCommittedReportMap[quarterlyReport.newFormData.reportingRequirementIndex]
           );
 
       if (

--- a/app/components/Form/ProjectSummaryReportFormSummary.tsx
+++ b/app/components/Form/ProjectSummaryReportFormSummary.tsx
@@ -56,9 +56,6 @@ const ProjectSummaryReportFormSummary: React.FC<Props> = ({
             node {
               newFormData
               operation
-              formChangeByPreviousFormChangeId {
-                newFormData
-              }
             }
           }
         }
@@ -153,8 +150,6 @@ const ProjectSummaryReportFormSummary: React.FC<Props> = ({
         uiSchema={projectSummaryReportUiSchema}
         formContext={{
           operation: projectSummaryReport.operation,
-          oldData:
-            projectSummaryReport.formChangeByPreviousFormChangeId?.newFormData,
           latestCommittedData:
             latestCommittedProjectSummaryFormChanges?.edges[0]?.node
               ?.newFormData,

--- a/app/components/Form/ProjectSummaryReportFormSummary.tsx
+++ b/app/components/Form/ProjectSummaryReportFormSummary.tsx
@@ -88,7 +88,8 @@ const ProjectSummaryReportFormSummary: React.FC<Props> = ({
 
   const filteredSchema = getFilteredSchema(
     projectSummaryReportFormBySlug.jsonSchema.schema as JSONSchema7,
-    projectSummaryReport || {}
+    projectSummaryReport || {},
+    latestCommittedProjectSummaryFormChanges?.edges[0]?.node
   );
 
   const allFormChangesPristine = useMemo(

--- a/app/lib/theme/CustomDiffFields.tsx
+++ b/app/lib/theme/CustomDiffFields.tsx
@@ -194,8 +194,7 @@ const renderDiffString = ({
         contentSuffixElement(`${id}-${diffOldClsName}`, contentSuffix)
       );
     }
-  }
-   else if (newData !== null && newData !== undefined) {
+  } else if (newData !== null && newData !== undefined) {
     components.push(<span className={diffOldClsName}>Not Entered</span>);
     components.push(renderArrow());
     components.push(

--- a/app/lib/theme/CustomDiffFields.tsx
+++ b/app/lib/theme/CustomDiffFields.tsx
@@ -60,7 +60,6 @@ const renderArrow = () => {
 };
 
 const renderDiffData = ({
-  oldData,
   newData,
   latestCommittedData,
   id,
@@ -72,31 +71,10 @@ const renderDiffData = ({
   contentSuffix,
 }) => {
   let components = [];
-  if (oldData !== null && oldData !== undefined) {
-    components.push(
-      <NumberFormatWrapper
-        value={oldData}
-        className={diffOldClsName}
-        id={`${id}-${diffOldClsName}`}
-        isMoney={isMoney}
-        isPercentage={isPercentage}
-        decimalScale={decimalScale}
-      />
-    );
-    if (contentSuffix) {
-      components.push(
-        contentSuffixElement(`${id}-${diffOldClsName}`, contentSuffix)
-      );
-    }
-    if (newData !== null && newData !== undefined) {
-      components.push(renderArrow());
-    }
-  }
 
   if (
     latestCommittedData !== null &&
     latestCommittedData !== undefined &&
-    latestCommittedData !== oldData &&
     latestCommittedData !== newData
   ) {
     components.push(
@@ -120,8 +98,8 @@ const renderDiffData = ({
   if (
     newData !== null &&
     newData !== undefined &&
-    oldData !== null &&
-    oldData !== undefined
+    latestCommittedData !== null &&
+    latestCommittedData !== undefined
   ) {
     components.push(
       <NumberFormatWrapper
@@ -162,7 +140,6 @@ const renderDiffData = ({
 };
 
 const renderDiffString = ({
-  oldData,
   newData,
   latestCommittedData,
   id,
@@ -172,31 +149,10 @@ const renderDiffString = ({
   diffNewClsName,
 }) => {
   let components = [];
-  if (oldData !== null && oldData !== undefined) {
-    components.push(
-      <StringFormatWrapper
-        value={isDate ? getLocaleFormattedDate(oldData) : oldData}
-        className={diffOldClsName}
-        id={`${id}-${diffOldClsName}`}
-      />
-    );
-    if (contentSuffix) {
-      components.push(
-        contentSuffixElement(`${id}-${diffOldClsName}`, contentSuffix)
-      );
-    }
-    if (
-      (newData !== null && newData !== undefined) ||
-      (latestCommittedData !== null && latestCommittedData !== undefined)
-    ) {
-      components.push(renderArrow());
-    }
-  }
 
   if (
     latestCommittedData !== null &&
     latestCommittedData !== undefined &&
-    latestCommittedData !== oldData &&
     latestCommittedData !== newData
   ) {
     components.push(
@@ -223,8 +179,8 @@ const renderDiffString = ({
   if (
     newData !== null &&
     newData !== undefined &&
-    oldData !== null &&
-    oldData !== undefined
+    latestCommittedData !== null &&
+    latestCommittedData !== undefined
   ) {
     components.push(
       <StringFormatWrapper
@@ -238,7 +194,8 @@ const renderDiffString = ({
         contentSuffixElement(`${id}-${diffOldClsName}`, contentSuffix)
       );
     }
-  } else if (newData !== null && newData !== undefined) {
+  }
+   else if (newData !== null && newData !== undefined) {
     components.push(<span className={diffOldClsName}>Not Entered</span>);
     components.push(renderArrow());
     components.push(
@@ -261,13 +218,10 @@ const CUSTOM_DIFF_FIELDS = {
   StringField: (props) => {
     const { idSchema, formData, formContext, uiSchema } = props;
     const id = idSchema?.$id;
-    const oldData = formContext?.oldData?.[props.name];
     const latestCommittedData = formContext?.latestCommittedData?.[props.name];
     const isDate = uiSchema["ui:widget"] === "DateWidget";
     const contentSuffix = uiSchema?.["ui:options"]?.contentSuffix;
-
     return renderDiffString({
-      oldData,
       newData: formData,
       latestCommittedData,
       id,
@@ -280,7 +234,6 @@ const CUSTOM_DIFF_FIELDS = {
   NumberField: (props) => {
     const { idSchema, formData, formContext, uiSchema } = props;
     const id = idSchema?.$id;
-    const oldData = formContext?.oldData?.[props.name];
     const latestCommittedData = formContext?.latestCommittedData?.[props.name];
     const isMoney = uiSchema?.isMoney;
     const isPercentage = uiSchema?.isPercentage;
@@ -289,8 +242,6 @@ const CUSTOM_DIFF_FIELDS = {
 
     // Handle text data mapping for certain number values
     let textData = uiSchema?.["ui:options"]?.text as string;
-    let oldTextData =
-      formContext?.oldUiSchema?.[props.name]?.["ui:options"]?.text;
     let latestCommittedTextData =
       formContext?.latestCommittedUiSchema?.[props.name]?.["ui:options"]?.text;
 
@@ -298,7 +249,6 @@ const CUSTOM_DIFF_FIELDS = {
       // Switch to string rendering for archive
       textData = undefined;
       return renderDiffString({
-        oldData: oldTextData,
         newData: textData,
         latestCommittedData: latestCommittedTextData,
         id,
@@ -309,9 +259,8 @@ const CUSTOM_DIFF_FIELDS = {
       });
     }
 
-    if (oldTextData || textData || latestCommittedTextData) {
+    if (textData || latestCommittedTextData) {
       return renderDiffString({
-        oldData: oldTextData,
         newData: textData,
         latestCommittedData: latestCommittedTextData,
         id,
@@ -322,7 +271,6 @@ const CUSTOM_DIFF_FIELDS = {
       });
     } else {
       return renderDiffData({
-        oldData,
         newData: formData,
         latestCommittedData,
         id,

--- a/app/lib/theme/schemaFilteringHelpers.ts
+++ b/app/lib/theme/schemaFilteringHelpers.ts
@@ -46,18 +46,17 @@ export const getSchemaAndDataIncludingCalculatedValues = (
 };
 
 // `getFilteredSchema` can only be used when all form values are found in `newFormData` (most of the time, calculated values are queried outside of `newFormData`, so in forms with calculated values, use `getSchemaAndDataIncludingCalculatedValues` instead)
-export const getFilteredSchema = (formSchema: JSONSchema7, formChange) => {
+export const getFilteredSchema = (formSchema: JSONSchema7, formChange, latestCommittedFormChange) => {
   const filteredSchema = JSON.parse(JSON.stringify(formSchema));
   const newDataObject = {};
 
   for (const key of Object.keys(filteredSchema.properties)) {
     if (
       formChange?.newFormData?.[key] ===
-      formChange?.formChangeByPreviousFormChangeId?.newFormData?.[key]
+      latestCommittedFormChange?.newFormData?.[key]
     )
       delete filteredSchema.properties[key];
     else newDataObject[key] = formChange.newFormData?.[key];
   }
-
   return { formSchema: filteredSchema, formData: newDataObject };
 };

--- a/app/lib/theme/schemaFilteringHelpers.ts
+++ b/app/lib/theme/schemaFilteringHelpers.ts
@@ -46,7 +46,11 @@ export const getSchemaAndDataIncludingCalculatedValues = (
 };
 
 // `getFilteredSchema` can only be used when all form values are found in `newFormData` (most of the time, calculated values are queried outside of `newFormData`, so in forms with calculated values, use `getSchemaAndDataIncludingCalculatedValues` instead)
-export const getFilteredSchema = (formSchema: JSONSchema7, formChange, latestCommittedFormChange) => {
+export const getFilteredSchema = (
+  formSchema: JSONSchema7,
+  formChange,
+  latestCommittedFormChange
+) => {
   const filteredSchema = JSON.parse(JSON.stringify(formSchema));
   const newDataObject = {};
 

--- a/app/tests/unit/components/Form/ProjectAnnualReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectAnnualReportFormSummary.test.tsx
@@ -126,7 +126,7 @@ const mockQueryPayload = {
                   submittedDate: "2025-07-01T23:59:59.999-07:00",
                   reportingRequirementIndex: 1,
                 },
-              }
+              },
             },
             {
               node: {
@@ -141,10 +141,10 @@ const mockQueryPayload = {
                     "I am an unchanged received date on Annual Report #2",
                   reportingRequirementIndex: 2,
                 },
-              }
+              },
             },
-          ]
-        }
+          ],
+        },
       };
     return result;
   },

--- a/app/tests/unit/components/Form/ProjectAnnualReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectAnnualReportFormSummary.test.tsx
@@ -143,6 +143,19 @@ const mockQueryPayload = {
                 },
               },
             },
+            {
+              node: {
+                newFormData: {
+                  status: "on_track",
+                  comments: "I have been deleted",
+                  projectId: 1,
+                  reportType: "Annual",
+                  reportDueDate: "2022-06-03T23:59:59.999-07:00",
+                  submittedDate: "2022-06-24T23:59:59.999-07:00",
+                  reportingRequirementIndex: 4,
+                },
+              },
+            },
           ],
         },
       };

--- a/app/tests/unit/components/Form/ProjectAnnualReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectAnnualReportFormSummary.test.tsx
@@ -41,18 +41,6 @@ const mockQueryPayload = {
                 },
                 operation: "UPDATE",
                 changeStatus: "committed",
-                formChangeByPreviousFormChangeId: {
-                  changeStatus: "committed",
-                  newFormData: {
-                    status: "on_track",
-                    comments: "I am the old comment on Annual Report #1",
-                    projectId: 1,
-                    reportType: "Annual",
-                    reportDueDate: "2025-06-18T23:59:59.999-07:00",
-                    submittedDate: "2025-07-01T23:59:59.999-07:00",
-                    reportingRequirementIndex: 1,
-                  },
-                },
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -76,20 +64,6 @@ const mockQueryPayload = {
                 },
                 operation: "UPDATE",
                 changeStatus: "committed",
-                formChangeByPreviousFormChangeId: {
-                  changeStatus: "committed",
-                  newFormData: {
-                    status: "on_track",
-                    comments: "I am an unchanged comment on Annual Report #2",
-                    projectId: 1,
-                    reportType: "Annual",
-                    reportDueDate:
-                      "I am an unchanged due date on Annual Report #2",
-                    submittedDate:
-                      "I am an unchanged received date on Annual Report #2",
-                    reportingRequirementIndex: 2,
-                  },
-                },
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -111,7 +85,6 @@ const mockQueryPayload = {
                 },
                 operation: "UPDATE",
                 changeStatus: "committed",
-                formChangeByPreviousFormChangeId: null,
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -133,7 +106,6 @@ const mockQueryPayload = {
                 },
                 operation: "ARCHIVE",
                 changeStatus: "committed",
-                formChangeByPreviousFormChangeId: null,
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -141,6 +113,38 @@ const mockQueryPayload = {
             },
           ],
         },
+        latestCommittedAnnualReportFormChanges: {
+          edges: [
+            {
+              node: {
+                newFormData: {
+                  status: "on_track",
+                  comments: "I am the old comment on Annual Report #1",
+                  projectId: 1,
+                  reportType: "Annual",
+                  reportDueDate: "2025-06-18T23:59:59.999-07:00",
+                  submittedDate: "2025-07-01T23:59:59.999-07:00",
+                  reportingRequirementIndex: 1,
+                },
+              }
+            },
+            {
+              node: {
+                newFormData: {
+                  status: "on_track",
+                  comments: "I am an unchanged comment on Annual Report #2",
+                  projectId: 1,
+                  reportType: "Annual",
+                  reportDueDate:
+                    "I am an unchanged due date on Annual Report #2",
+                  submittedDate:
+                    "I am an unchanged received date on Annual Report #2",
+                  reportingRequirementIndex: 2,
+                },
+              }
+            },
+          ]
+        }
       };
     return result;
   },

--- a/app/tests/unit/components/Form/ProjectAttachmentsFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectAttachmentsFormSummary.test.tsx
@@ -34,6 +34,7 @@ const defaultQueryResolver = {
               node: {
                 id: "test-attachment-form-change-id-1",
                 rowId: 1,
+                operation: "CREATE",
                 asProjectAttachment: {
                   attachmentByAttachmentId: {
                     id: "test-attachment-id-1",
@@ -52,6 +53,7 @@ const defaultQueryResolver = {
               node: {
                 id: "test-attachment-form-change-id-2",
                 rowId: 2,
+                operation: "CREATE",
                 asProjectAttachment: {
                   attachmentByAttachmentId: {
                     id: "test-attachment-id-2",
@@ -59,6 +61,25 @@ const defaultQueryResolver = {
                     fileType: "image/jpeg",
                     fileSize: 123456,
                     createdAt: "2021-01-02T00:00:00.000Z",
+                    cifUserByCreatedBy: {
+                      fullName: "Test User 2",
+                    },
+                  },
+                },
+              },
+            },
+            {
+              node: {
+                id: "test-attachment-form-change-id-3",
+                rowId: 3,
+                operation: "ARCHIVE",
+                asProjectAttachment: {
+                  attachmentByAttachmentId: {
+                    id: "test-attachment-id-3",
+                    fileName: "test-attachment-3.jpg",
+                    fileType: "image/jpeg",
+                    fileSize: 123456,
+                    createdAt: "2021-01-03T00:00:00.000Z",
                     cifUserByCreatedBy: {
                       fullName: "Test User 2",
                     },
@@ -111,11 +132,20 @@ describe("The project's attachment page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("Displays all attachments", () => {
+  it("Displays all attachments that were created in this revision", () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();
 
+    expect(screen.getAllByText(/Create/i)).toHaveLength(2);
     expect(screen.getByText(/test-attachment-1.jpg/i)).toBeInTheDocument();
     expect(screen.getByText(/test-attachment-2.jpg/i)).toBeInTheDocument();
+  });
+
+  it("Displays all attachments that were archived in this revision", () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getAllByText(/Archive/i)).toHaveLength(1);
+    expect(screen.getByText(/test-attachment-3.jpg/i)).toBeInTheDocument();
   });
 });

--- a/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
@@ -77,7 +77,6 @@ const mockQueryPayload = {
                   fullName: "I was added",
                 },
               },
-              formChangeByPreviousFormChangeId: null,
               formByJsonSchemaName: {
                 jsonSchema: projectContactProdSchema,
               },

--- a/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
@@ -104,53 +104,53 @@ const mockQueryPayload = {
             },
           },
         ],
-        latestCommittedProjectContactFormChanges: {
-          edges: [
-            {
-              node: {
-                newFormData: {
-                  contactIndex: 1,
-                  contactId: 1,
-                  projectId: 1,
-                },
-                asProjectContact: {
-                  contactByContactId: {
-                    fullName: "Test Full Name primary PREVIOUS",
-                  },
-                },
-              }
-            },
-            {
-              node: {
-                newFormData: {
-                  contactIndex: 1,
-                  contactId: 2,
-                  projectId: 1,
-                },
-                asProjectContact: {
-                  contactByContactId: {
-                    fullName: "I did not change",
-                  },
-                },
-              }
-            },
-            {
-              node: {
-                newFormData: {
-                  contactIndex: 4,
-                  contactId: 4,
-                  projectId: 1,
-                },
-                asProjectContact: {
-                  contactByContactId: {
-                    fullName: "I was removed",
-                  },
-                },
-              }
-            }
-          ]
-        }
       },
+      latestCommittedProjectContactFormChanges: {
+        edges: [
+          {
+            node: {
+              newFormData: {
+                contactIndex: 1,
+                contactId: 1,
+                projectId: 1,
+              },
+              asProjectContact: {
+                contactByContactId: {
+                  fullName: "Test Full Name primary PREVIOUS",
+                },
+              },
+            }
+          },
+          {
+            node: {
+              newFormData: {
+                contactIndex: 1,
+                contactId: 2,
+                projectId: 1,
+              },
+              asProjectContact: {
+                contactByContactId: {
+                  fullName: "I did not change",
+                },
+              },
+            }
+          },
+          {
+            node: {
+              newFormData: {
+                contactIndex: 4,
+                contactId: 4,
+                projectId: 1,
+              },
+              asProjectContact: {
+                contactByContactId: {
+                  fullName: "I was removed",
+                },
+              },
+            }
+          }
+        ]
+      }
     };
     return result;
   },

--- a/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
@@ -118,7 +118,7 @@ const mockQueryPayload = {
                   fullName: "Test Full Name primary PREVIOUS",
                 },
               },
-            }
+            },
           },
           {
             node: {
@@ -132,7 +132,7 @@ const mockQueryPayload = {
                   fullName: "I did not change",
                 },
               },
-            }
+            },
           },
           {
             node: {
@@ -146,10 +146,10 @@ const mockQueryPayload = {
                   fullName: "I was removed",
                 },
               },
-            }
-          }
-        ]
-      }
+            },
+          },
+        ],
+      },
     };
     return result;
   },

--- a/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectContactFormSummary.test.tsx
@@ -39,18 +39,6 @@ const mockQueryPayload = {
                   fullName: "Test Full Name primary",
                 },
               },
-              formChangeByPreviousFormChangeId: {
-                newFormData: {
-                  contactIndex: 1,
-                  contactId: 1,
-                  projectId: 1,
-                },
-                asProjectContact: {
-                  contactByContactId: {
-                    fullName: "Test Full Name primary PREVIOUS",
-                  },
-                },
-              },
               formByJsonSchemaName: {
                 jsonSchema: projectContactProdSchema,
               },
@@ -68,18 +56,6 @@ const mockQueryPayload = {
               asProjectContact: {
                 contactByContactId: {
                   fullName: "I did not change",
-                },
-              },
-              formChangeByPreviousFormChangeId: {
-                newFormData: {
-                  contactIndex: 1,
-                  contactId: 2,
-                  projectId: 1,
-                },
-                asProjectContact: {
-                  contactByContactId: {
-                    fullName: "I did not change",
-                  },
                 },
               },
               formByJsonSchemaName: {
@@ -122,7 +98,44 @@ const mockQueryPayload = {
                 },
               },
               operation: "ARCHIVE",
-              formChangeByPreviousFormChangeId: {
+              formByJsonSchemaName: {
+                jsonSchema: projectContactProdSchema,
+              },
+            },
+          },
+        ],
+        latestCommittedProjectContactFormChanges: {
+          edges: [
+            {
+              node: {
+                newFormData: {
+                  contactIndex: 1,
+                  contactId: 1,
+                  projectId: 1,
+                },
+                asProjectContact: {
+                  contactByContactId: {
+                    fullName: "Test Full Name primary PREVIOUS",
+                  },
+                },
+              }
+            },
+            {
+              node: {
+                newFormData: {
+                  contactIndex: 1,
+                  contactId: 2,
+                  projectId: 1,
+                },
+                asProjectContact: {
+                  contactByContactId: {
+                    fullName: "I did not change",
+                  },
+                },
+              }
+            },
+            {
+              node: {
                 newFormData: {
                   contactIndex: 4,
                   contactId: 4,
@@ -133,13 +146,10 @@ const mockQueryPayload = {
                     fullName: "I was removed",
                   },
                 },
-              },
-              formByJsonSchemaName: {
-                jsonSchema: projectContactProdSchema,
-              },
-            },
-          },
-        ],
+              }
+            }
+          ]
+        }
       },
     };
     return result;

--- a/app/tests/unit/components/Form/ProjectEmissionIntensityReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectEmissionIntensityReportFormSummary.test.tsx
@@ -42,17 +42,23 @@ const defaultMockResolver = {
                 baselineEmissionIntensity: 0.87654321,
               },
               operation: "UPDATE",
-              formChangeByPreviousFormChangeId: {
-                newFormData: {
-                  comments: "squirtle",
-                  reportType: "TEIMP",
-                  projectId: 1,
-                  reportingRequirementIndex: 1,
-                  reportingRequirementId: 1,
-                  baselineEmissionIntensity: 0.985145,
-                },
-              },
               formDataRecordId: 1,
+            },
+          },
+        ],
+      },
+      latestCommittedEmissionIntensityReportFormChange: {
+        edges: [
+          {
+            node: {
+              newFormData: {
+                comments: "squirtle",
+                reportType: "TEIMP",
+                projectId: 1,
+                reportingRequirementIndex: 1,
+                reportingRequirementId: 1,
+                baselineEmissionIntensity: 0.985145,
+              },
             },
           },
         ],
@@ -195,13 +201,19 @@ describe("the emission intensity report form component", () => {
                     targetEmissionIntensity: 0,
                   },
                   operation: "UPDATE",
-                  formChangeByPreviousFormChangeId: {
-                    newFormData: {
-                      baselineEmissionIntensity: 0,
-                      targetEmissionIntensity: 0.12345678,
-                      postProjectEmissionIntensity: 654,
-                      totalLifetimeEmissionReduction: 456,
-                    },
+                },
+              },
+            ],
+          },
+          latestCommittedEmissionIntensityReportFormChange: {
+            edges: [
+              {
+                node: {
+                  newFormData: {
+                    baselineEmissionIntensity: 0,
+                    targetEmissionIntensity: 0.12345678,
+                    postProjectEmissionIntensity: 654,
+                    totalLifetimeEmissionReduction: 456,
                   },
                 },
               },
@@ -235,6 +247,7 @@ describe("the emission intensity report form component", () => {
     expect(screen.getByText("654.00000000")).toHaveClass("diffOld");
     expect(screen.getByText("456.00000000")).toHaveClass("diffOld");
   });
+
   it("displays calculated values diff", () => {
     const customPayload = {
       Form() {
@@ -257,12 +270,6 @@ describe("the emission intensity report form component", () => {
                   maximumPerformanceMilestoneAmount: 123,
                   actualPerformanceMilestoneAmount: null,
                   operation: "UPDATE",
-                  formChangeByPreviousFormChangeId: {
-                    calculatedEiPerformance: 20,
-                    paymentPercentage: 44,
-                    maximumPerformanceMilestoneAmount: 321,
-                    actualPerformanceMilestoneAmount: 789,
-                  },
                 },
               },
             ],
@@ -273,10 +280,10 @@ describe("the emission intensity report form component", () => {
                 node: {
                   isPristine: false,
                   operation: "UPDATE",
-                  calculatedEiPerformance: 22,
-                  paymentPercentage: 13,
-                  maximumPerformanceMilestoneAmount: 741,
-                  actualPerformanceMilestoneAmount: 357,
+                  calculatedEiPerformance: 20,
+                  paymentPercentage: 44,
+                  maximumPerformanceMilestoneAmount: 321,
+                  actualPerformanceMilestoneAmount: 789,
                 },
               },
             ],
@@ -289,31 +296,27 @@ describe("the emission intensity report form component", () => {
     expect(
       screen.getByText(/ghg emission intensity performance/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/20\.00 %/i)).toBeInTheDocument(); //old calculatedEiPerformance
+    expect(screen.getByText(/20\.00 %/i)).toBeInTheDocument(); //latest committed calculatedEiPerformance
     expect(screen.getByText(/10\.00 %/i)).toBeInTheDocument(); //new calculatedEiPerformance
-    expect(screen.getByText(/22\.00 %/i)).toBeInTheDocument(); //latest committed calculatedEiPerformance
 
     expect(
       screen.getByText(
         /payment percentage of performance milestone amount \(%\)/i
       )
     ).toBeInTheDocument();
-    expect(screen.getByText(/44\.00 %/i)).toBeInTheDocument(); //old paymentPercentage
+    expect(screen.getByText(/44\.00 %/i)).toBeInTheDocument(); //latest committed paymentPercentage
     expect(screen.getByText(/40\.00 %/i)).toBeInTheDocument(); //new paymentPercentage
-    expect(screen.getByText(/13\.00 %/i)).toBeInTheDocument(); //latest committed paymentPercentage
 
     expect(
       screen.getByText(/maximum performance milestone amount/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/\$321\.00/i)).toBeInTheDocument(); //old maximumPerformanceMilestoneAmount
+    expect(screen.getByText(/\$321\.00/i)).toBeInTheDocument(); //latest committed maximumPerformanceMilestoneAmount
     expect(screen.getByText(/\$123\.00/i)).toBeInTheDocument(); //new maximumPerformanceMilestoneAmount
-    expect(screen.getByText(/\$741\.00/i)).toBeInTheDocument(); //latest committed maximumPerformanceMilestoneAmount
 
     expect(
       screen.getByText(/actual performance milestone amount/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/\$789\.00/i)).toBeInTheDocument(); //old actualPerformanceMilestoneAmount
-    expect(screen.getByText(/\$357\.00/i)).toBeInTheDocument(); //latest committed actualPerformanceMilestoneAmount
+    expect(screen.getByText(/\$789\.00/i)).toBeInTheDocument(); //latest committed actualPerformanceMilestoneAmount
   });
 
   it("renders the help tooltips", () => {

--- a/app/tests/unit/components/Form/ProjectFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectFormSummary.test.tsx
@@ -51,41 +51,41 @@ const mockQueryPayload = {
             name: "Test Project Status Name",
           },
         },
-        latestCommittedProjectFormChanges: {
-          edges: [
-            {
-              node: {
-                rank: 987654321,
-                newFormData: {
-                  proposalReference: "Test Proposal Reference PREVIOUS",
-                  operatorId: 1,
-                  fundingStreamRfpId: 1,
-                  projectStatusId: 1,
-                  summary: "Test Summary",
-                  projectName: "Test Project Name",
-                  totalFundingRequest: 100.0,
-                  score: 1,
-                  projectType: "test project type PREVIOUS",
+      },
+      latestCommittedProjectFormChanges: {
+        edges: [
+          {
+            node: {
+              rank: 987654321,
+              newFormData: {
+                proposalReference: "Test Proposal Reference PREVIOUS",
+                operatorId: 1,
+                fundingStreamRfpId: 1,
+                projectStatusId: 1,
+                summary: "Test Summary",
+                projectName: "Test Project Name",
+                totalFundingRequest: 100.0,
+                score: 1,
+                projectType: "test project type PREVIOUS",
+              },
+              asProject: {
+                operatorByOperatorId: {
+                  legalName: "Test Legal Name PREVIOUS",
+                  bcRegistryId: "Test BC Registry ID",
                 },
-                asProject: {
-                  operatorByOperatorId: {
-                    legalName: "Test Legal Name PREVIOUS",
-                    bcRegistryId: "Test BC Registry ID",
+                fundingStreamRfpByFundingStreamRfpId: {
+                  year: 2020,
+                  fundingStreamByFundingStreamId: {
+                    description: "Test Funding Stream Description",
                   },
-                  fundingStreamRfpByFundingStreamRfpId: {
-                    year: 2020,
-                    fundingStreamByFundingStreamId: {
-                      description: "Test Funding Stream Description",
-                    },
-                  },
-                  projectStatusByProjectStatusId: {
-                    name: "Test Project Status Name",
-                  },
+                },
+                projectStatusByProjectStatusId: {
+                  name: "Test Project Status Name",
                 },
               },
             },
-          ],
-        },
+          },
+        ],
       },
     };
     return result;

--- a/app/tests/unit/components/Form/ProjectFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectFormSummary.test.tsx
@@ -51,34 +51,40 @@ const mockQueryPayload = {
             name: "Test Project Status Name",
           },
         },
-        formChangeByPreviousFormChangeId: {
-          rank: 987654321,
-          newFormData: {
-            proposalReference: "Test Proposal Reference PREVIOUS",
-            operatorId: 1,
-            fundingStreamRfpId: 1,
-            projectStatusId: 1,
-            summary: "Test Summary",
-            projectName: "Test Project Name",
-            totalFundingRequest: 100.0,
-            score: 1,
-            projectType: "test project type PREVIOUS",
-          },
-          asProject: {
-            operatorByOperatorId: {
-              legalName: "Test Legal Name PREVIOUS",
-              bcRegistryId: "Test BC Registry ID",
-            },
-            fundingStreamRfpByFundingStreamRfpId: {
-              year: 2020,
-              fundingStreamByFundingStreamId: {
-                description: "Test Funding Stream Description",
+        latestCommittedProjectFormChanges: {
+          edges: [
+            {
+              node: {
+                rank: 987654321,
+                newFormData: {
+                  proposalReference: "Test Proposal Reference PREVIOUS",
+                  operatorId: 1,
+                  fundingStreamRfpId: 1,
+                  projectStatusId: 1,
+                  summary: "Test Summary",
+                  projectName: "Test Project Name",
+                  totalFundingRequest: 100.0,
+                  score: 1,
+                  projectType: "test project type PREVIOUS",
+                },
+                asProject: {
+                  operatorByOperatorId: {
+                    legalName: "Test Legal Name PREVIOUS",
+                    bcRegistryId: "Test BC Registry ID",
+                  },
+                  fundingStreamRfpByFundingStreamRfpId: {
+                    year: 2020,
+                    fundingStreamByFundingStreamId: {
+                      description: "Test Funding Stream Description",
+                    },
+                  },
+                  projectStatusByProjectStatusId: {
+                    name: "Test Project Status Name",
+                  },
+                },
               },
             },
-            projectStatusByProjectStatusId: {
-              name: "Test Project Status Name",
-            },
-          },
+          ],
         },
       },
     };

--- a/app/tests/unit/components/Form/ProjectFundingAgreementFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectFundingAgreementFormSummary.test.tsx
@@ -63,27 +63,6 @@ const mockQueryPayloadEP = {
                 grossPaymentsToDate: "1.00",
                 isPristine: false,
                 operation: "UPDATE",
-                formChangeByPreviousFormChangeId: {
-                  proponentsSharePercentage: 10, // will trigger three diffs
-                  totalProjectValue: 12, // will trigger three diffs
-                  newFormData: {
-                    projectId: "Test Project ID",
-                    maxFundingAmount: 200,
-                    provinceSharePercentage: 50,
-                    holdbackPercentage: 10.23,
-                    anticipatedFundingAmount: 300,
-                    proponentCost: 100,
-                    contractStartDate: "2021-01-01T23:59:59.999-07:00",
-                    projectAssetsLifeEndDate: "2021-12-31T23:59:59.999-07:00",
-                    additionalFundingSources: [
-                      {
-                        source: "Test Source Name",
-                        amount: 1000,
-                        status: "Awaiting Approval",
-                      },
-                    ],
-                  },
-                },
               },
             },
           ],
@@ -92,17 +71,25 @@ const mockQueryPayloadEP = {
           edges: [
             {
               node: {
-                proponentsSharePercentage: 15, // will trigger three diffs
-                totalProjectValue: 18, // will trigger three diffs
+                proponentsSharePercentage: 10, // will trigger three diffs
+                totalProjectValue: 12, // will trigger three diffs
                 newFormData: {
-                  // add data as required
+                  projectId: "Test Project ID",
+                  maxFundingAmount: 200,
+                  provinceSharePercentage: 50,
+                  holdbackPercentage: 10.23,
+                  anticipatedFundingAmount: 300,
+                  proponentCost: 100,
+                  contractStartDate: "2021-01-01T23:59:59.999-07:00",
+                  projectAssetsLifeEndDate: "2021-12-31T23:59:59.999-07:00",
+                  additionalFundingSources: [
+                    {
+                      source: "Test Source Name",
+                      amount: 1000,
+                      status: "Awaiting Approval",
+                    },
+                  ],
                 },
-                eligibleExpensesToDate: "1.00",
-                holdbackAmountToDate: "0.00",
-                netPaymentsToDate: "1.00",
-                grossPaymentsToDate: "1.00",
-                isPristine: false,
-                operation: "UPDATE",
               },
             },
           ],
@@ -154,20 +141,6 @@ const mockQueryPayloadIA = {
                 calculatedTotalPaymentAmountToDate: "511.0",
                 isPristine: false,
                 operation: "UPDATE",
-                formChangeByPreviousFormChangeId: {
-                  proponentsSharePercentage: 14, // will trigger three diffs
-                  totalProjectValue: 16, // will trigger three diffs
-                  newFormData: {
-                    projectId: "Test Project ID",
-                    maxFundingAmount: 500,
-                    provinceSharePercentage: 50,
-                    anticipatedFundingAmount: 200,
-                    proponentCost: 100,
-                    contractStartDate: "2021-01-01T23:59:59.999-07:00",
-                    projectAssetsLifeEndDate:
-                      "2023-03-28T14:41:23.626132-07:00",
-                  },
-                },
               },
             },
           ],
@@ -176,12 +149,17 @@ const mockQueryPayloadIA = {
           edges: [
             {
               node: {
-                proponentsSharePercentage: 21, // will trigger three diffs
-                totalProjectValue: 24, // will trigger three diffs
-                newFormData: {},
-                calculatedTotalPaymentAmountToDate: "511.0",
-                isPristine: false,
-                operation: "UPDATE",
+                proponentsSharePercentage: 14, // will trigger three diffs
+                totalProjectValue: 16, // will trigger three diffs
+                newFormData: {
+                  projectId: "Test Project ID",
+                  maxFundingAmount: 500,
+                  provinceSharePercentage: 50,
+                  anticipatedFundingAmount: 200,
+                  proponentCost: 100,
+                  contractStartDate: "2021-01-01T23:59:59.999-07:00",
+                  projectAssetsLifeEndDate: "2023-03-28T14:41:23.626132-07:00",
+                },
               },
             },
           ],
@@ -307,17 +285,11 @@ describe("The Project Funding Agreement Form Summary", () => {
       screen.getByText("10.00 %", { selector: ".diffOld" })
     ).toBeInTheDocument(); // old proponentsSharePercentage
     expect(
-      screen.getByText("15.00 %", { selector: ".diffOld" })
-    ).toBeInTheDocument(); // latest committed proponentsSharePercentage
-    expect(
       screen.getByText("$6.00", { selector: ".diffNew" })
     ).toBeInTheDocument(); // new totalProjectValue
     expect(
       screen.getByText("$12.00", { selector: ".diffOld" })
     ).toBeInTheDocument(); // old totalProjectValue
-    expect(
-      screen.getByText("$18.00", { selector: ".diffOld" })
-    ).toBeInTheDocument(); // latest committed totalProjectValue
   });
 
   it("Displays diffs of the the data fields that have changed for an IA form", () => {
@@ -340,18 +312,12 @@ describe("The Project Funding Agreement Form Summary", () => {
     expect(
       screen.getByText("14.00 %", { selector: ".diffOld" })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("21.00 %", { selector: ".diffOld" })
-    ).toBeInTheDocument();
 
     expect(
       screen.getByText("$8.00", { selector: ".diffNew" })
     ).toBeInTheDocument();
     expect(
       screen.getByText("$16.00", { selector: ".diffOld" })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("$24.00", { selector: ".diffOld" })
     ).toBeInTheDocument();
   });
 

--- a/app/tests/unit/components/Form/ProjectFundingAgreementFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectFundingAgreementFormSummary.test.tsx
@@ -38,8 +38,8 @@ const mockQueryPayloadEP = {
           edges: [
             {
               node: {
-                proponentsSharePercentage: 5, // will trigger three diffs
-                totalProjectValue: 6, // will trigger three diffs
+                proponentsSharePercentage: 5, // will trigger diffs
+                totalProjectValue: 6, // will trigger diffs
                 newFormData: {
                   projectId: "Test Project ID",
                   maxFundingAmount: 200,
@@ -71,8 +71,8 @@ const mockQueryPayloadEP = {
           edges: [
             {
               node: {
-                proponentsSharePercentage: 10, // will trigger three diffs
-                totalProjectValue: 12, // will trigger three diffs
+                proponentsSharePercentage: 10, // will trigger diffs
+                totalProjectValue: 12, // will trigger diffs
                 newFormData: {
                   projectId: "Test Project ID",
                   maxFundingAmount: 200,
@@ -127,8 +127,8 @@ const mockQueryPayloadIA = {
           edges: [
             {
               node: {
-                proponentsSharePercentage: 7, // will trigger three diffs
-                totalProjectValue: 8, // will trigger three diffs
+                proponentsSharePercentage: 7, // will trigger diffs
+                totalProjectValue: 8, // will trigger diffs
                 newFormData: {
                   projectId: "Test Project ID",
                   maxFundingAmount: 501,
@@ -149,8 +149,8 @@ const mockQueryPayloadIA = {
           edges: [
             {
               node: {
-                proponentsSharePercentage: 14, // will trigger three diffs
-                totalProjectValue: 16, // will trigger three diffs
+                proponentsSharePercentage: 14, // will trigger diffs
+                totalProjectValue: 16, // will trigger diffs
                 newFormData: {
                   projectId: "Test Project ID",
                   maxFundingAmount: 500,

--- a/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
@@ -84,7 +84,6 @@ const mockQueryPayload = {
                       fullName: "Test Full Name Create",
                     },
                   },
-                  formChangeByPreviousFormChangeId: null,
                 },
                 projectManagerLabel: {
                   label: "Test Third Label",

--- a/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
@@ -207,7 +207,6 @@ describe("The ProjectManagerForm", () => {
   it("Only displays diffs of the the data fields that have changed", () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();
-    screen.logTestingPlaygroundURL();
 
     expect(screen.getByText("Test Full Name Update")).toBeInTheDocument();
     expect(

--- a/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
@@ -42,18 +42,6 @@ const mockQueryPayload = {
                       fullName: "Test Full Name Update",
                     },
                   },
-                  formChangeByPreviousFormChangeId: {
-                    newFormData: {
-                      projectId: 1,
-                      cifUserId: 1,
-                      projectManagerLabelId: 1,
-                    },
-                    asProjectManager: {
-                      cifUserByCifUserId: {
-                        fullName: "Test Full Name Update PREVIOUS",
-                      },
-                    },
-                  },
                 },
                 projectManagerLabel: {
                   label: "Test First Label",
@@ -73,18 +61,6 @@ const mockQueryPayload = {
                   asProjectManager: {
                     cifUserByCifUserId: {
                       fullName: "Test Full Name Archive",
-                    },
-                  },
-                  formChangeByPreviousFormChangeId: {
-                    newFormData: {
-                      projectId: 1,
-                      cifUserId: 1,
-                      projectManagerLabelId: 1,
-                    },
-                    asProjectManager: {
-                      cifUserByCifUserId: {
-                        fullName: "Test Full Name Archive PREVIOUS",
-                      },
                     },
                   },
                 },
@@ -130,18 +106,6 @@ const mockQueryPayload = {
                       fullName: "Test Full Name No Change",
                     },
                   },
-                  formChangeByPreviousFormChangeId: {
-                    newFormData: {
-                      projectId: 1,
-                      cifUserId: 4,
-                      projectManagerLabelId: 4,
-                    },
-                    asProjectManager: {
-                      cifUserByCifUserId: {
-                        fullName: "Test Full Name No Change",
-                      },
-                    },
-                  },
                 },
                 projectManagerLabel: {
                   label: "Test Fourth Label",
@@ -149,6 +113,52 @@ const mockQueryPayload = {
               },
             },
           ],
+        },
+        latestCommittedProjectManagerFormChanges: {
+          edges: [
+            {
+              node: {
+                newFormData: {
+                  projectId: 1,
+                  cifUserId: 1,
+                  projectManagerLabelId: 1,
+                },
+                asProjectManager: {
+                  cifUserByCifUserId: {
+                    fullName: "Test Full Name Update PREVIOUS",
+                  },
+                },
+              }
+            },
+            {
+              node: {
+                newFormData: {
+                  projectId: 1,
+                  cifUserId: 1,
+                  projectManagerLabelId: 1,
+                },
+                asProjectManager: {
+                  cifUserByCifUserId: {
+                    fullName: "Test Full Name Archive PREVIOUS",
+                  },
+                },
+              }
+            },
+            {
+              node: {
+                newFormData: {
+                  projectId: 1,
+                  cifUserId: 4,
+                  projectManagerLabelId: 4,
+                },
+                asProjectManager: {
+                  cifUserByCifUserId: {
+                    fullName: "Test Full Name No Change",
+                  },
+                },
+              }
+            }
+          ]
         },
       },
     };
@@ -197,6 +207,7 @@ describe("The ProjectManagerForm", () => {
   it("Only displays diffs of the the data fields that have changed", () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();
+    screen.logTestingPlaygroundURL();
 
     expect(screen.getByText("Test Full Name Update")).toBeInTheDocument();
     expect(

--- a/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectManagerFormSummary.test.tsx
@@ -127,7 +127,7 @@ const mockQueryPayload = {
                     fullName: "Test Full Name Update PREVIOUS",
                   },
                 },
-              }
+              },
             },
             {
               node: {
@@ -141,7 +141,7 @@ const mockQueryPayload = {
                     fullName: "Test Full Name Archive PREVIOUS",
                   },
                 },
-              }
+              },
             },
             {
               node: {
@@ -155,9 +155,9 @@ const mockQueryPayload = {
                     fullName: "Test Full Name No Change",
                   },
                 },
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
       },
     };

--- a/app/tests/unit/components/Form/ProjectMilestoneReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectMilestoneReportFormSummary.test.tsx
@@ -83,7 +83,7 @@ const mockQueryPayload = {
                 reportingRequirementId: 1,
                 hasExpenses: true,
               },
-            }
+            },
           },
           {
             node: {
@@ -94,10 +94,10 @@ const mockQueryPayload = {
                 reportingRequirementIndex: 2,
                 reportingRequirementId: 2,
               },
-            }
+            },
           },
-        ]
-      }
+        ],
+      },
     };
     return result;
   },
@@ -285,10 +285,10 @@ describe("The Project Milestone Report Form Summary", () => {
                     adjustedGrossAmount: 12,
                     adjustedHoldbackAmount: 13,
                   },
-                }
-              }
-            ]
-          }
+                },
+              },
+            ],
+          },
         };
         return result;
       },

--- a/app/tests/unit/components/Form/ProjectMilestoneReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectMilestoneReportFormSummary.test.tsx
@@ -50,17 +50,6 @@ const mockQueryPayload = {
                 adjustedHoldbackAmount: 88,
               },
               operation: "UPDATE",
-              formChangeByPreviousFormChangeId: {
-                newFormData: {
-                  description: "bulbasaur",
-                  projectId: 1,
-                  reportingRequirementIndex: 1,
-                  reportDueDate: "2020-01-01T13:59:59.999-07:00",
-                  reportType: "Advanced",
-                  reportingRequirementId: 1,
-                  hasExpenses: true,
-                },
-              },
               formDataRecordId: 1,
             },
           },
@@ -72,24 +61,43 @@ const mockQueryPayload = {
                 description: "Removed comment",
                 projectId: 1,
                 reportDueDate: "2020-01-07T23:59:59.999-07:00",
-                reportingRequirementIndex: 1,
+                reportingRequirementIndex: 2,
                 reportingRequirementId: 2,
               },
               operation: "ARCHIVE",
-              formChangeByPreviousFormChangeId: {
-                newFormData: {
-                  description: "Removed comment",
-                  projectId: 1,
-                  reportDueDate: "2020-01-05T23:59:59.999-07:00",
-                  reportingRequirementIndex: 1,
-                  reportingRequirementId: 2,
-                },
-              },
               formDataRecordId: 2,
             },
           },
         ],
       },
+      latestCommittedMilestoneFormChanges: {
+        edges: [
+          {
+            node: {
+              newFormData: {
+                description: "bulbasaur",
+                projectId: 1,
+                reportingRequirementIndex: 1,
+                reportDueDate: "2020-01-01T13:59:59.999-07:00",
+                reportType: "Advanced",
+                reportingRequirementId: 1,
+                hasExpenses: true,
+              },
+            }
+          },
+          {
+            node: {
+              newFormData: {
+                description: "Removed comment",
+                projectId: 1,
+                reportDueDate: "2020-01-05T23:59:59.999-07:00",
+                reportingRequirementIndex: 2,
+                reportingRequirementId: 2,
+              },
+            }
+          },
+        ]
+      }
     };
     return result;
   },
@@ -125,7 +133,7 @@ describe("The Project Milestone Report Form Summary", () => {
     componentTestingHelper.renderComponent();
 
     // changed fields
-    expect(screen.getByText("Milestone Description")).toBeInTheDocument();
+    expect(screen.getByText(/Milestone Description/i)).toBeInTheDocument();
     expect(screen.getByText("Milestone Type")).toBeInTheDocument();
 
     // Archive milestone report
@@ -220,97 +228,6 @@ describe("The Project Milestone Report Form Summary", () => {
     expect(screen.getByText(/\$88\.00/i)).toBeInTheDocument();
   });
 
-  it("Displays diffs of the data fields that were updated and shows latest committed values", () => {
-    const latestCommittedData = {
-      latestCommittedMilestoneFormChanges: {
-        edges: [
-          {
-            node: {
-              newFormData: {
-                totalEligibleExpenses: 1000,
-                description: "charmander",
-                projectId: 1,
-                reportingRequirementIndex: 1,
-                reportType: "General",
-                reportDueDate: "2020-01-10T23:59:59.999-07:00",
-                reportingRequirementId: 1,
-                hasExpenses: true,
-                calculatedGrossAmount: 567,
-                calculatedNetAmount: 789,
-                calculatedHoldbackAmount: 891,
-                adjustedNetAmount: 89,
-                adjustedGrossAmount: 67,
-                adjustedHoldbackAmount: 91,
-              },
-            },
-          },
-        ],
-      },
-    };
-
-    const mockQueryPayloadLatestCommitted = {
-      ...mockQueryPayload,
-      ProjectRevision() {
-        const originalProjectRevision = mockQueryPayload.ProjectRevision();
-        const modifiedProjectRevision = {
-          ...originalProjectRevision,
-          latestCommittedMilestoneFormChanges: {
-            edges: [
-              {
-                node: {
-                  newFormData:
-                    latestCommittedData.latestCommittedMilestoneFormChanges
-                      .edges[0].node.newFormData,
-                },
-              },
-            ],
-          },
-        };
-        return modifiedProjectRevision;
-      },
-    };
-
-    componentTestingHelper.defaultQueryResolver =
-      mockQueryPayloadLatestCommitted;
-    componentTestingHelper.loadQuery(mockQueryPayloadLatestCommitted);
-    componentTestingHelper.renderComponent();
-
-    // calculated values
-    expect(
-      screen.getByText("Gross Payment Amount This Milestone")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\$567\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/\$999\.00/i)).toBeInTheDocument();
-    expect(
-      screen.getByText("Net Payment Amount This Milestone")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\$789\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/\$888\.00/i)).toBeInTheDocument();
-    expect(
-      screen.getByText("Holdback Amount This Milestone")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\$891\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/\$111\.00/i)).toBeInTheDocument();
-
-    // adjusted values
-    expect(
-      screen.getByText("Gross Payment Amount This Milestone (Adjusted)")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\$99\.00/i)).toBeInTheDocument();
-
-    expect(screen.getByText(/\$89\.00/i)).toBeInTheDocument();
-    expect(
-      screen.getByText("Net Payment Amount This Milestone (Adjusted)")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\$11\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/\$67\.00/i)).toBeInTheDocument();
-    expect(
-      screen.getByText("Holdback Amount This Milestone (Adjusted)")
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\$88\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/\$91\.00/i)).toBeInTheDocument();
-  });
-
   it("Displays diffs of the data fields that were updated and the old values", () => {
     const mockQueryPayloadWithDiffs = {
       Form() {
@@ -344,28 +261,34 @@ describe("The Project Milestone Report Form Summary", () => {
                     adjustedHoldbackAmount: 23,
                   },
                   operation: "UPDATE",
-                  formChangeByPreviousFormChangeId: {
-                    newFormData: {
-                      description: "bulbasaur",
-                      projectId: 1,
-                      reportingRequirementIndex: 1,
-                      reportDueDate: "2020-01-01T13:59:59.999-07:00",
-                      reportType: "Advanced",
-                      reportingRequirementId: 1,
-                      hasExpenses: true,
-                      calculatedNetAmount: 111,
-                      calculatedGrossAmount: 112,
-                      calculatedHoldbackAmount: 113,
-                      adjustedNetAmount: 11,
-                      adjustedGrossAmount: 12,
-                      adjustedHoldbackAmount: 13,
-                    },
-                  },
                   formDataRecordId: 1,
                 },
               },
             ],
           },
+          latestCommittedMilestoneFormChanges: {
+            edges: [
+              {
+                node: {
+                  newFormData: {
+                    description: "bulbasaur",
+                    projectId: 1,
+                    reportingRequirementIndex: 1,
+                    reportDueDate: "2020-01-01T13:59:59.999-07:00",
+                    reportType: "Advanced",
+                    reportingRequirementId: 1,
+                    hasExpenses: true,
+                    calculatedNetAmount: 111,
+                    calculatedGrossAmount: 112,
+                    calculatedHoldbackAmount: 113,
+                    adjustedNetAmount: 11,
+                    adjustedGrossAmount: 12,
+                    adjustedHoldbackAmount: 13,
+                  },
+                }
+              }
+            ]
+          }
         };
         return result;
       },
@@ -425,7 +348,6 @@ describe("The Project Milestone Report Form Summary", () => {
                 node: {
                   id: "Tooltip Test 1",
                   isPristine: null,
-                  formChangeByPreviousFormChangeId: null,
                   newFormData: {
                     calculatedGrossAmount: 123,
                     calculatedHoldbackAmount: 456,

--- a/app/tests/unit/components/Form/ProjectQuarterlyReportForm.test.tsx
+++ b/app/tests/unit/components/Form/ProjectQuarterlyReportForm.test.tsx
@@ -48,7 +48,6 @@ const defaultMockResolver = {
               },
               operation: "CREATE",
               changeStatus: "pending",
-              formChangeByPreviousFormChangeId: null,
               formByJsonSchemaName: {
                 jsonSchema: reportingRequirementProdSchema,
               },
@@ -68,7 +67,6 @@ const defaultMockResolver = {
               },
               operation: "CREATE",
               changeStatus: "pending",
-              formChangeByPreviousFormChangeId: null,
               formByJsonSchemaName: {
                 jsonSchema: reportingRequirementProdSchema,
               },

--- a/app/tests/unit/components/Form/ProjectQuarterlyReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectQuarterlyReportFormSummary.test.tsx
@@ -36,14 +36,6 @@ const mockQueryPayload = {
                   reportingRequirementIndex: 1,
                 },
                 operation: "UPDATE",
-                formChangeByPreviousFormChangeId: {
-                  newFormData: {
-                    comments: "Test comment",
-                    projectId: 1,
-                    reportDueDate: "2020-01-01T23:59:59.999-07:00",
-                    reportingRequirementIndex: 1,
-                  },
-                },
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -57,34 +49,9 @@ const mockQueryPayload = {
                   comments: "Not updated comment",
                   projectId: 1,
                   reportDueDate: "2020-01-03T23:59:59.999-07:00",
-                  reportingRequirementIndex: 1,
+                  reportingRequirementIndex: 2,
                 },
                 operation: "UPDATE",
-                formChangeByPreviousFormChangeId: {
-                  newFormData: {
-                    comments: "Not updated comment",
-                    projectId: 1,
-                    reportDueDate: "2020-01-03T23:59:59.999-07:00",
-                    reportingRequirementIndex: 1,
-                  },
-                },
-                formByJsonSchemaName: {
-                  jsonSchema: reportingRequirementProdSchema,
-                },
-              },
-            },
-            {
-              node: {
-                id: "Test ID - 3",
-                isPristine: false,
-                newFormData: {
-                  comments: "Added comment",
-                  projectId: 1,
-                  reportDueDate: "2020-01-04T23:59:59.999-07:00",
-                  reportingRequirementIndex: 1,
-                },
-                operation: "CREATE",
-                formChangeByPreviousFormChangeId: null,
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -98,17 +65,25 @@ const mockQueryPayload = {
                   comments: "Removed comment",
                   projectId: 1,
                   reportDueDate: "2020-01-05T23:59:59.999-07:00",
-                  reportingRequirementIndex: 1,
+                  reportingRequirementIndex: 3,
                 },
                 operation: "ARCHIVE",
-                formChangeByPreviousFormChangeId: {
-                  newFormData: {
-                    comments: "Removed comment",
-                    projectId: 1,
-                    reportDueDate: "2020-01-05T23:59:59.999-07:00",
-                    reportingRequirementIndex: 1,
-                  },
+                formByJsonSchemaName: {
+                  jsonSchema: reportingRequirementProdSchema,
                 },
+              },
+            },
+            {
+              node: {
+                id: "Test ID - 3",
+                isPristine: false,
+                newFormData: {
+                  comments: "Added comment",
+                  projectId: 1,
+                  reportDueDate: "2020-01-04T23:59:59.999-07:00",
+                  reportingRequirementIndex: 4,
+                },
+                operation: "CREATE",
                 formByJsonSchemaName: {
                   jsonSchema: reportingRequirementProdSchema,
                 },
@@ -116,6 +91,43 @@ const mockQueryPayload = {
             },
           ],
         },
+        latestCommittedProjectQuarterlyReportFormChanges: {
+          edges: [
+            {
+              node: {
+                id: "Test ID 5",
+                newFormData: {
+                  comments: "Test comment",
+                  projectId: 1,
+                  reportDueDate: "2020-01-01T23:59:59.999-07:00",
+                  reportingRequirementIndex: 1,
+                },
+              },
+            },
+            {
+              node: {
+                id: "Test ID 6",
+                newFormData: {
+                  comments: "Not updated comment",
+                  projectId: 1,
+                  reportDueDate: "2020-01-03T23:59:59.999-07:00",
+                  reportingRequirementIndex: 2,
+                },
+              },
+            },
+            {
+              node: {
+                id: "Test ID 7",
+                newFormData: {
+                  comments: "Removed comment",
+                  projectId: 1,
+                  reportDueDate: "2020-01-05T23:59:59.999-07:00",
+                  reportingRequirementIndex: 3,
+                },
+              },
+            },
+          ]
+        }
       };
     return result;
   },

--- a/app/tests/unit/components/Form/ProjectQuarterlyReportFormSummary.test.tsx
+++ b/app/tests/unit/components/Form/ProjectQuarterlyReportFormSummary.test.tsx
@@ -126,8 +126,8 @@ const mockQueryPayload = {
                 },
               },
             },
-          ]
-        }
+          ],
+        },
       };
     return result;
   },

--- a/app/tests/unit/components/ProjectRevision/CollapsibleFormWidget.test.tsx
+++ b/app/tests/unit/components/ProjectRevision/CollapsibleFormWidget.test.tsx
@@ -50,35 +50,69 @@ const mockQueryPayload = {
             name: "Test Project Status Name",
           },
         },
-        formChangeByPreviousFormChangeId: {
-          newFormData: {
-            proposalReference: "Test Proposal Reference PREVIOUS",
-            operatorId: 1,
-            fundingStreamRfpId: 1,
-            projectStatusId: 1,
-            summary: "Test Summary",
-            projectName: "Test Project Name",
-            totalFundingRequest: 100.0,
-            score: 1,
-            projectType: "test project type PREVIOUS",
-          },
-          asProject: {
-            operatorByOperatorId: {
-              legalName: "Test Legal Name PREVIOUS",
-              bcRegistryId: "Test BC Registry ID",
-            },
-            fundingStreamRfpByFundingStreamRfpId: {
-              year: 2020,
-              fundingStreamByFundingStreamId: {
-                description: "Test Funding Stream Description",
-              },
-            },
-            projectStatusByProjectStatusId: {
-              name: "Test Project Status Name",
-            },
-          },
-        },
+        // formChangeByPreviousFormChangeId: {
+        //   newFormData: {
+        //     proposalReference: "Test Proposal Reference PREVIOUS",
+        //     operatorId: 1,
+        //     fundingStreamRfpId: 1,
+        //     projectStatusId: 1,
+        //     summary: "Test Summary",
+        //     projectName: "Test Project Name",
+        //     totalFundingRequest: 100.0,
+        //     score: 1,
+        //     projectType: "test project type PREVIOUS",
+        //   },
+          // asProject: {
+          //   operatorByOperatorId: {
+          //     legalName: "Test Legal Name PREVIOUS",
+          //     bcRegistryId: "Test BC Registry ID",
+          //   },
+          //   fundingStreamRfpByFundingStreamRfpId: {
+          //     year: 2020,
+          //     fundingStreamByFundingStreamId: {
+          //       description: "Test Funding Stream Description",
+          //     },
+          //   },
+          //   projectStatusByProjectStatusId: {
+          //     name: "Test Project Status Name",
+          //   },
+          // },
+        // },
       },
+      latestCommittedProjectFormChanges: {
+        edges: [
+          {
+            node: {
+              newFormData: {
+                proposalReference: "Test Proposal Reference PREVIOUS",
+                operatorId: 1,
+                fundingStreamRfpId: 1,
+                projectStatusId: 1,
+                summary: "Test Summary",
+                projectName: "Test Project Name",
+                totalFundingRequest: 100.0,
+                score: 1,
+                projectType: "test project type PREVIOUS",
+              },
+              asProject: {
+                operatorByOperatorId: {
+                  legalName: "Test Legal Name PREVIOUS",
+                  bcRegistryId: "Test BC Registry ID",
+                },
+                fundingStreamRfpByFundingStreamRfpId: {
+                  year: 2020,
+                  fundingStreamByFundingStreamId: {
+                    description: "Test Funding Stream Description",
+                  },
+                },
+                projectStatusByProjectStatusId: {
+                  name: "Test Project Status Name",
+                },
+              },
+            }
+          }
+        ]
+      }
     };
   },
 };

--- a/app/tests/unit/components/ProjectRevision/CollapsibleFormWidget.test.tsx
+++ b/app/tests/unit/components/ProjectRevision/CollapsibleFormWidget.test.tsx
@@ -50,34 +50,6 @@ const mockQueryPayload = {
             name: "Test Project Status Name",
           },
         },
-        // formChangeByPreviousFormChangeId: {
-        //   newFormData: {
-        //     proposalReference: "Test Proposal Reference PREVIOUS",
-        //     operatorId: 1,
-        //     fundingStreamRfpId: 1,
-        //     projectStatusId: 1,
-        //     summary: "Test Summary",
-        //     projectName: "Test Project Name",
-        //     totalFundingRequest: 100.0,
-        //     score: 1,
-        //     projectType: "test project type PREVIOUS",
-        //   },
-          // asProject: {
-          //   operatorByOperatorId: {
-          //     legalName: "Test Legal Name PREVIOUS",
-          //     bcRegistryId: "Test BC Registry ID",
-          //   },
-          //   fundingStreamRfpByFundingStreamRfpId: {
-          //     year: 2020,
-          //     fundingStreamByFundingStreamId: {
-          //       description: "Test Funding Stream Description",
-          //     },
-          //   },
-          //   projectStatusByProjectStatusId: {
-          //     name: "Test Project Status Name",
-          //   },
-          // },
-        // },
       },
       latestCommittedProjectFormChanges: {
         edges: [
@@ -109,10 +81,10 @@ const mockQueryPayload = {
                   name: "Test Project Status Name",
                 },
               },
-            }
-          }
-        ]
-      }
+            },
+          },
+        ],
+      },
     };
   },
 };

--- a/app/tests/unit/lib/theme/CustomDiffFields.test.tsx
+++ b/app/tests/unit/lib/theme/CustomDiffFields.test.tsx
@@ -77,8 +77,8 @@ const latestCommittedData = {
 };
 
 describe("The Object Field Template", () => {
-  // 111
-  it("shows diffs when there is an old, new, and latest committed value, and old !== latest committed", () => {
+
+  it("shows diffs when there is a latest committed value that has been changed in the new data", () => {
     const componentUnderTest = render(
       <FormBase
         tagName={"dl"}
@@ -87,9 +87,7 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: oldFormData,
-          latestCommittedData,
-          oldUiSchema: oldUiTestSchema,
+          latestCommittedData: latestCommittedData,
           latestCommittedUiSchema: latestCommittedUiTestSchema,
           operation: "UPDATE",
         }}
@@ -97,62 +95,22 @@ describe("The Object Field Template", () => {
     );
 
     expect(componentUnderTest.getByText("stringTest NEW")).toBeInTheDocument();
-    expect(componentUnderTest.getByText("stringTest OLD")).toBeInTheDocument();
-    expect(
-      componentUnderTest.getByText(/^(.*?)stringTest LAST COMMITTED/)
-    ).toBeInTheDocument();
+    expect(componentUnderTest.getByText("stringTest LAST COMMITTED")).toBeInTheDocument();
+    expect(getComputedStyle(componentUnderTest.getByText("stringTest LAST COMMITTED")).textDecoration).toBe("line-through")
+
     expect(componentUnderTest.getByText("$100.00")).toBeInTheDocument();
-    expect(componentUnderTest.getByText("$200.00")).toBeInTheDocument();
     expect(componentUnderTest.getByText("$300.00")).toBeInTheDocument();
-    expect(
-      componentUnderTest.getByText("I replaced the ID")
-    ).toBeInTheDocument();
-    expect(
-      componentUnderTest.getByText("I replaced the OLD ID")
-    ).toBeInTheDocument();
+    expect(getComputedStyle(componentUnderTest.getByText("$300.00")).textDecoration).toBe("line-through")
     expect(
       componentUnderTest.getByText(/I am the last committed value/i)
     ).toBeInTheDocument();
-  });
-
-  it("shows diffs when there is an old, new, and latest committed value and old === latest committed", () => {
-    const componentUnderTest = render(
-      <FormBase
-        tagName={"dl"}
-        fields={CUSTOM_DIFF_FIELDS}
-        schema={testSchema as JSONSchema7}
-        uiSchema={uiTestSchema}
-        formData={formData}
-        formContext={{
-          oldData: oldFormData,
-          latestCommittedData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
-          latestCommittedUiSchema: oldUiTestSchema,
-          operation: "UPDATE",
-        }}
-      />
-    );
-
-    expect(componentUnderTest.getByText("stringTest NEW")).toBeInTheDocument();
-    expect(componentUnderTest.getByText("stringTest OLD")).toBeInTheDocument();
-    expect(
-      componentUnderTest.queryByText(/^(.*?)LAST COMMITTED/)
-    ).not.toBeInTheDocument();
-    expect(componentUnderTest.getByText("$100.00")).toBeInTheDocument();
-    expect(componentUnderTest.getByText("$200.00")).toBeInTheDocument();
-    expect(componentUnderTest.queryByText("$300.00")).not.toBeInTheDocument();
     expect(
       componentUnderTest.getByText("I replaced the ID")
     ).toBeInTheDocument();
-    expect(
-      componentUnderTest.getByText("I replaced the OLD ID")
-    ).toBeInTheDocument();
-    expect(
-      componentUnderTest.queryByText(/I am the last committed value/i)
-    ).not.toBeInTheDocument();
   });
+
   // 101
-  it("shows data has been removed when there is old data and latest committed data but no new data", () => {
+  it("shows data has been removed when there is latest committed data but no new data", () => {
     const componentUnderTest = render(
       <FormBase
         tagName={"dl"}
@@ -161,24 +119,23 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={null}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
           operation: "CREATE",
           latestCommittedData,
+          latestCommittedUiSchema: latestCommittedUiTestSchema
         }}
       />
     );
-    expect(componentUnderTest.getByText("stringTest OLD")).toHaveClass(
+    expect(componentUnderTest.getByText("stringTest LAST COMMITTED")).toHaveClass(
       "diffOld"
     );
-    expect(componentUnderTest.getByText("$200.00")).toHaveClass("diffOld");
-    expect(componentUnderTest.getByText("I replaced the OLD ID")).toHaveClass(
+    expect(componentUnderTest.getByText("$300.00")).toHaveClass("diffOld");
+    expect(componentUnderTest.getByText("I am the last committed value")).toHaveClass(
       "diffOld"
     );
   });
 
   // 010
-  it("shows data has been added when there is newData, and there is no old data or no latest committed", () => {
+  it("shows data has been added when there is newData, and there is no latest committed", () => {
     const componentUnderTest = render(
       <FormBase
         tagName={"dl"}
@@ -187,7 +144,6 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: null,
           oldUiSchema: oldUiTestSchema,
           operation: "CREATE",
         }}
@@ -203,7 +159,7 @@ describe("The Object Field Template", () => {
     );
   });
   // 011
-  it("shows data has been added when there is newData, latest and there is no old data", () => {
+  it("shows data has been added when there is newData, and latest committed data", () => {
     const componentUnderTest = render(
       <FormBase
         tagName={"dl"}
@@ -212,10 +168,8 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: null,
-          oldUiSchema: oldUiTestSchema,
           operation: "CREATE",
-          latestCommittedData: latestCommittedData,
+          latestCommittedData,
         }}
       />
     );
@@ -240,8 +194,8 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
+          latestCommittedData,
+          latestCommittedUiSchema: latestCommittedUiTestSchema,
           operation: "UPDATE",
         }}
       />
@@ -262,8 +216,7 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
+          latestCommittedData: latestCommittedData,
           operation: "UPDATE",
         }}
       />
@@ -282,8 +235,8 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
+          latestCommittedData,
+          latestCommittedUiSchema: latestCommittedUiTestSchema,
           operation: "UPDATE",
         }}
       />
@@ -303,8 +256,6 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={null}
         formContext={{
-          oldData: null,
-          oldUiSchema: null,
           operation: "CREATE",
         }}
       />
@@ -323,8 +274,8 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formData}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
+          latestCommittedData,
+          latestCommittedUiSchema: latestCommittedUiTestSchema,
           operation: "UPDATE",
           isAmendmentsAndOtherRevisionsSpecific: true,
         }}
@@ -334,10 +285,11 @@ describe("The Object Field Template", () => {
     expect(componentUnderTest.getByText("stringTest NEW")).toHaveClass(
       "diffNew"
     );
-    expect(componentUnderTest.getByText("stringTest OLD")).toHaveClass(
+    expect(componentUnderTest.getByText("stringTest LAST COMMITTED")).toHaveClass(
       "diffOld"
     );
   });
+
   it("handles 0 when latest committed data is 0", () => {
     const latestCommittedDataWithZero = {
       stringTest: "stringTest LAST COMMITTED",
@@ -377,16 +329,15 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formDataWithZero}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
           operation: "UPDATE",
           isAmendmentsAndOtherRevisionsSpecific: true,
           latestCommittedData,
         }}
       />
     );
-    expect(componentUnderTest.getByText("0")).toHaveClass("diffNew");
+    expect(componentUnderTest.getByText("$0.00")).toHaveClass("diffNew");
   });
+
   it("handles 0 when latestCommittedData and oldData are 0, (the same), and newFormData exists", () => {
     const latestCommittedDataWithZero = {
       stringTest: "stringTest LAST COMMITTED",
@@ -418,34 +369,8 @@ describe("The Object Field Template", () => {
     expect(componentUnderTest.getAllByText("0")).toHaveLength(1);
     expect(componentUnderTest.getByText("100")).toHaveClass("diffNew");
   });
-  it("handles 0 when oldData is 0", () => {
-    const oldDataWithZero = {
-      stringTest: "",
-      numberTest: 0,
-      numericIdTest: 0,
-    };
-    const componentUnderTest = render(
-      <FormBase
-        tagName={"dl"}
-        fields={CUSTOM_DIFF_FIELDS}
-        schema={testSchema as JSONSchema7}
-        uiSchema={uiTestSchema}
-        formData={formData}
-        formContext={{
-          oldData: oldDataWithZero,
-          oldUiSchema: oldUiTestSchema,
-          operation: "UPDATE",
-          isAmendmentsAndOtherRevisionsSpecific: true,
-          latestCommittedData,
-        }}
-      />
-    );
 
-    expect(componentUnderTest.getAllByText("0")[0]).toHaveClass("diffOld");
-    expect(componentUnderTest.getAllByText("0")).toHaveLength(1);
-  });
-
-  it("handles 0 when oldData and latest data is 0", () => {
+  it("handles 0 when latest data is 0", () => {
     const oldDataWithZero = {
       stringTest: "",
       numberTest: 0,
@@ -476,7 +401,7 @@ describe("The Object Field Template", () => {
     expect(componentUnderTest.getAllByText("0")[0]).toHaveClass("diffOld");
     expect(componentUnderTest.getAllByText("0")).toHaveLength(1);
   });
-  it("handles 0 when newData and latest data is 0", () => {
+  it.only("handles 0 when newData and latest data is 0", () => {
     const formDataWithZero = {
       stringTest: "",
       numberTest: 0,
@@ -495,8 +420,6 @@ describe("The Object Field Template", () => {
         uiSchema={uiTestSchema}
         formData={formDataWithZero}
         formContext={{
-          oldData: oldFormData,
-          oldUiSchema: oldUiTestSchema,
           operation: "UPDATE",
           isAmendmentsAndOtherRevisionsSpecific: true,
           latestCommittedData: latestCommittedDataWithZero,

--- a/app/tests/unit/lib/theme/CustomDiffFields.test.tsx
+++ b/app/tests/unit/lib/theme/CustomDiffFields.test.tsx
@@ -80,7 +80,6 @@ latestCommittedUiTestSchema.numericIdTest["ui:options"].text =
   "I am the last committed value";
 
 describe("The Object Field Template", () => {
-
   it("shows diffs when the latest committed value exists and has been changed in the new data", () => {
     const componentUnderTest = render(
       <FormBase
@@ -98,7 +97,9 @@ describe("The Object Field Template", () => {
     );
 
     expect(componentUnderTest.getByText("stringTest NEW")).toBeInTheDocument();
-    expect(componentUnderTest.getByText("stringTest LAST COMMITTED")).toBeInTheDocument();
+    expect(
+      componentUnderTest.getByText("stringTest LAST COMMITTED")
+    ).toBeInTheDocument();
 
     expect(componentUnderTest.getByText("100")).toBeInTheDocument();
     expect(componentUnderTest.getByText("300")).toBeInTheDocument();
@@ -125,17 +126,17 @@ describe("The Object Field Template", () => {
         formContext={{
           operation: "CREATE",
           latestCommittedData,
-          latestCommittedUiSchema: latestCommittedUiTestSchema
+          latestCommittedUiSchema: latestCommittedUiTestSchema,
         }}
       />
     );
-    expect(componentUnderTest.getByText("stringTest LAST COMMITTED")).toHaveClass(
-      "diffOld"
-    );
+    expect(
+      componentUnderTest.getByText("stringTest LAST COMMITTED")
+    ).toHaveClass("diffOld");
     expect(componentUnderTest.getByText("$30.00")).toHaveClass("diffOld");
-    expect(componentUnderTest.getByText("I am the last committed value")).toHaveClass(
-      "diffOld"
-    );
+    expect(
+      componentUnderTest.getByText("I am the last committed value")
+    ).toHaveClass("diffOld");
   });
 
   it("shows data has been added when there is newData, and there is no latest committed", () => {
@@ -286,9 +287,9 @@ describe("The Object Field Template", () => {
     expect(componentUnderTest.getByText("stringTest NEW")).toHaveClass(
       "diffNew"
     );
-    expect(componentUnderTest.getByText("stringTest LAST COMMITTED")).toHaveClass(
-      "diffOld"
-    );
+    expect(
+      componentUnderTest.getByText("stringTest LAST COMMITTED")
+    ).toHaveClass("diffOld");
   });
 
   it("handles 0 when latest committed data is 0", () => {


### PR DESCRIPTION
This PR updates the way the custom diff fields represent the changes. The fields will now show the latest committed state (if any), and what will be changed/added/removed in the committing project revision. The intent is that it will be easier for users to discern what they will be changing about a project when applying a revision by avoiding showing them any intermittent states the project may have been in between the revision being created, and now.