### PR TITLE
chore: use the default crunchy image instead of a pinned version

### DIFF
--- a/chart/cas-cif/templates/postgres.yaml
+++ b/chart/cas-cif/templates/postgres.yaml
@@ -8,7 +8,7 @@ metadata:
     postgres-operator.crunchydata.com/pgbackrest-restore: {{ now | date "2006-01-02 15:04:05.000000" | quote }}
   {{- end }}
 spec:
-  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:ubi8-14.7-0
+  image: ""
   metadata:
     labels: {{ include "cas-cif.labels" . | nindent 6 }}
   postgresVersion: 14

--- a/database_backup_test/backup-test/templates/postgres.yaml
+++ b/database_backup_test/backup-test/templates/postgres.yaml
@@ -8,7 +8,7 @@ metadata:
     postgres-operator.crunchydata.com/pgbackrest-restore: {{ now | date "2006-01-02 15:04:05.000000" | quote }}
   {{- end }}
 spec:
-  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:ubi8-14.7-0
+  image: ""
   metadata:
     labels: {{ include "backup-test.labels" . | nindent 6 }}
   postgresVersion: 14


### PR DESCRIPTION
We have had our crunchy versions pinned. From the [docs](https://github.com/bcgov/crunchy-postgres/blob/main/charts/crunchy-postgres/values.yaml#L3): `it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default`.