### PR TITLE
Add 2024 to the funding stream rfp table

### DIFF
--- a/app/cypress/e2e/cif/project-revision/create-first-project-revision.cy.js
+++ b/app/cypress/e2e/cif/project-revision/create-first-project-revision.cy.js
@@ -13,13 +13,13 @@ describe("when creating a project, the project page", () => {
 
   it("allows an admin user to create an EP project", () => {
     //add new
-    cy.fillAndCheckNewProjectForm("Emissions Performance", "2020");
+    cy.fillAndCheckNewProjectForm("Emissions Performance", "2024");
     cy.happoAndAxe("EP Project New Form", "filled", "main");
     cy.findByRole("button", { name: /^confirm/i }).click();
 
     // add overview
     cy.url().should("include", "/form/0");
-    cy.findByText("Emissions Performance - 2020");
+    cy.findByText("Emissions Performance - 2024");
     cy.fillOverviewForm(
       "first operator legal name (AB1234567)",
       "Cement",
@@ -176,7 +176,7 @@ describe("when creating a project, the project page", () => {
     // project overview section
     cy.findByText(/RFP Year ID/i)
       .next()
-      .should("have.text", "Emissions Performance - 2020");
+      .should("have.text", "Emissions Performance - 2024");
     cy.findByText(/Operator Name/i)
       .next()
       .should("have.text", "first operator legal name (AB1234567)");

--- a/app/cypress/e2e/cif/project-revision/undo-changes.cy.js
+++ b/app/cypress/e2e/cif/project-revision/undo-changes.cy.js
@@ -92,7 +92,7 @@ describe("when undoing, the project revision page", () => {
     }).click();
     cy.addOrEditEmissionIntensityReport(
       "2022-01-01",
-      "2022-02-02",
+      "2022-04-02",
       "tCO",
       "1",
       "2",

--- a/schema/deploy/tables/funding_stream_rfp_002.sql
+++ b/schema/deploy/tables/funding_stream_rfp_002.sql
@@ -7,4 +7,3 @@ insert into cif.funding_stream_rfp (year, funding_stream_id) values
 (2024, 1), (2024, 2);
 
 commit;
-

--- a/schema/deploy/tables/funding_stream_rfp_002.sql
+++ b/schema/deploy/tables/funding_stream_rfp_002.sql
@@ -1,0 +1,10 @@
+-- Deploy cif:tables/funding_stream_rfp_002 to pg
+
+
+begin;
+
+insert into cif.funding_stream_rfp (year, funding_stream_id) values
+(2024, 1), (2024, 2);
+
+commit;
+

--- a/schema/revert/tables/funding_stream_rfp_002.sql
+++ b/schema/revert/tables/funding_stream_rfp_002.sql
@@ -1,0 +1,7 @@
+-- Revert cif:tables/funding_stream_rfp_002 from pg
+
+begin;
+
+delete from cif.funding_stream_rfp where year = 2024;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -374,3 +374,5 @@ mutations/commit_form_change [mutations/commit_form_change@1.15.0] 2023-11-22T19
 @1.16.4 2024-05-15T17:36:42Z Mike Vesprini <mike@button.is> # release v1.16.4
 @1.16.5 2024-05-22T23:00:27Z Mike Vesprini <mike@button.is> # release v1.16.5
 @1.17.0 2024-05-24T21:29:42Z Mike Vesprini <mike@button.is> # release v1.17.0
+
+tables/funding_stream_rfp_002 2024-05-28T22:41:57Z Brianna Cerkiewicz <briannacerkiewicz@pop-os> #  Add 2024 funding streams values to funding_stream_rfp table

--- a/schema/test/unit/tables/funding_stream_rfp_test.sql
+++ b/schema/test/unit/tables/funding_stream_rfp_test.sql
@@ -67,7 +67,7 @@ select results_eq(
   $$
     select count(*) from cif.funding_stream_rfp
   $$,
-  ARRAY['11'::bigint],
+  ARRAY['12'::bigint],
     'cif_internal can view all data from funding_stream_rfp'
 );
 

--- a/schema/test/unit/tables/funding_stream_rfp_test.sql
+++ b/schema/test/unit/tables/funding_stream_rfp_test.sql
@@ -67,7 +67,7 @@ select results_eq(
   $$
     select count(*) from cif.funding_stream_rfp
   $$,
-  ARRAY['10'::bigint],
+  ARRAY['11'::bigint],
     'cif_internal can view all data from funding_stream_rfp'
 );
 

--- a/schema/verify/tables/funding_stream_rfp_002.sql
+++ b/schema/verify/tables/funding_stream_rfp_002.sql
@@ -1,0 +1,13 @@
+-- Verify cif:tables/funding_stream_rfp_002 on pg
+
+begin;
+
+do $$
+  begin
+    assert (
+      (select count(*) from cif.funding_stream_rfp where year = 2024) = 2
+    ), 'EP and IA streams have been added for 2024';
+  end;
+$$;
+
+rollback;


### PR DESCRIPTION
card: https://github.com/bcgov/cas-cif/issues/1917#issuecomment-2135841962

This PR:
- add 2024 via sqitch
- changes the e2e test for creating a project to use 2024 instead of 2020