### PR TITLE
chore: adding default service account to deployment

### DIFF
--- a/chart/cas-cif/templates/app-deployment.yaml
+++ b/chart/cas-cif/templates/app-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         component: app
 {{ include "cas-cif.labels" . | indent 8 }}
     spec:
+      serviceAccountName: default
       initContainers:
       # The init container waits until the sqitch changes are deployed to the db
       - env: {{ include "cas-cif.cifUserPgEnv" . | nindent 10 }}


### PR DESCRIPTION
This will make it more robust to us experimenting with various service accounts for the deployment