### PR TITLE
fix: update helm value to match GGIRCS PGO cluster

### DIFF
--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -67,7 +67,7 @@ download-dags:
     hook: "pre-install,pre-upgrade"
 
 ggircs:
-  service: cas-ggircs-patroni
+  service: cas-ggircs-db-cas-postgres-cluster-pgbouncer
   instanceName: cas-ggircs
 
 metabase:


### PR DESCRIPTION
With GGIRCS moving over to the Postgres operator, this PR updates values in order to target the new database cluster.