### PR TITLE
chore: remove legacy fetch-and-save dag collection method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,13 +238,11 @@ install: CHART_DIR=./chart/cas-cif
 install: CHART_INSTANCE=cas-cif
 install: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
 										--set defaultImageTag=$(IMAGE_TAG) \
-	  								--set download-dags.dagConfiguration="$$dagConfig" \
 										--set ggircs.namespace=$(GGIRCS_NAMESPACE) \
 										--set ciip.prefix=$(CIIP_NAMESPACE_PREFIX) \
 										--values $(CHART_DIR)/values-$(ENVIRONMENT).yaml
 install:
 	@set -euo pipefail; \
-	dagConfig=$$(echo '{"org": "bcgov", "repo": "cas-cif", "ref": "$(GIT_SHA1)", "path": "dags/cas_cif_dags.py"}' | base64 -w0); \
 	helm dep up $(CHART_DIR); \
 	if ! helm status --namespace $(NAMESPACE) $(CHART_INSTANCE); then \
 		echo 'Installing the application'; \
@@ -284,7 +282,6 @@ restore: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESP
 										--set ggircs.namespace=$(GGIRCS_NAMESPACE) \
 										--set ciip.prefix=$(CIIP_NAMESPACE_PREFIX) \
 										--set deploy-db.enabled=false \
-										--set download-dags.enabled=false \
 										--set db.restore.enabled=true \
 										--set db.restore.targetTimestamp="$(TARGET_TIMESTAMP)" \
 										--values $(CHART_DIR)/values-$(ENVIRONMENT).yaml

--- a/chart/cas-cif/Chart.lock
+++ b/chart/cas-cif/Chart.lock
@@ -5,8 +5,5 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
-digest: sha256:25b1199cb01ef8541d6c57dddb6c5cbe2360244c7ebefd7d93553e88bf37bdc8
-generated: "2025-10-10T15:05:45.008940844-06:00"
+digest: sha256:ea401ebaaafbda80f2f8ab43b6eb5683dc50a8caeb4dd598bc709efc95dc202e
+generated: "2026-07-15T15:34:17.1701757-06:00"

--- a/chart/cas-cif/Chart.yaml
+++ b/chart/cas-cif/Chart.yaml
@@ -11,10 +11,5 @@ dependencies:
   - name: cas-airflow-dag-trigger
     version: 1.2.2
     repository: https://bcgov.github.io/cas-airflow
-    alias: download-dags
-    condition: download-dags.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
     alias: deploy-db
     condition: deploy-db.enabled

--- a/chart/cas-cif/values-dev.yaml
+++ b/chart/cas-cif/values-dev.yaml
@@ -15,6 +15,3 @@ db:
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
-
-download-dags:
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values-prod.yaml
+++ b/chart/cas-cif/values-prod.yaml
@@ -2,6 +2,3 @@ hostName: cif.gov.bc.ca
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
-
-download-dags:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values-test.yaml
+++ b/chart/cas-cif/values-test.yaml
@@ -25,6 +25,3 @@ db:
 
 deploy-db:
   airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
-download-dags:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca

--- a/chart/cas-cif/values.yaml
+++ b/chart/cas-cif/values.yaml
@@ -59,13 +59,6 @@ deploy-db:
   helm:
     hook: false
 
-download-dags:
-  enabled: true
-  airflowEndpoint: ~
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
 ggircs:
   service: cas-ggircs-db-cas-postgres-cluster-pgbouncer
   instanceName: cas-ggircs


### PR DESCRIPTION
Addresses #4715. Removes legacy method of getting Dags into Airflow, once bcgov/cas-airflow#231 is merged.

## Changes 🚧

- Remove old fetch and save from chart deployments.
